### PR TITLE
 feat(nicolive-program-selector): 新しい番組選択ダイアログの実装

### DIFF
--- a/app/components/nicolive-program-selector/Step.vue
+++ b/app/components/nicolive-program-selector/Step.vue
@@ -1,0 +1,24 @@
+<template>
+  <div class="step">
+   <div class="section">
+     <h3>{{ title }}</h3>
+     <p>{{ description }} </p>
+   </div>
+   <div class="section">
+     <ul class="list">
+       <slot />
+     </ul>
+   </div>
+  </div>
+</template>
+
+<script lang="ts" src="./Step.vue.ts"></script>
+
+<style lang="less" scoped>
+@import "../../styles/_colors";
+
+.section:last-child {
+  border-bottom: none;
+}
+
+</style>

--- a/app/components/nicolive-program-selector/Step.vue.ts
+++ b/app/components/nicolive-program-selector/Step.vue.ts
@@ -1,0 +1,11 @@
+import Vue from 'vue';
+import { Component, Prop } from 'vue-property-decorator';
+
+@Component({})
+export default class Step extends Vue {
+    @Prop()
+    title: string;
+
+    @Prop()
+    description: string;
+}

--- a/app/components/windows/NicoliveProgramSelector.vue
+++ b/app/components/windows/NicoliveProgramSelector.vue
@@ -36,8 +36,8 @@
         :class="'broadcast-channel-select-step'"
         :title="getStepTitle(currentStep)"
         :desciption="getStepDescription(currentStep)">
-          <li v-for="(channel, channelId) in queryParams.channels" :key="channelId" >
-            <a @click="onSelectChannel(channelId, channel.name)">
+          <li v-for="channel in queryParams.channels" :key="channel.id" >
+            <a @click="onSelectChannel(channel.id, channel.name)">
               <img :src="channel.thumbnailUrl" :alt="channel.name" class="channel-thumbnail" />
               <p class="anchor-text">{{ channel.name }}</p>
             </a>

--- a/app/components/windows/NicoliveProgramSelector.vue
+++ b/app/components/windows/NicoliveProgramSelector.vue
@@ -32,7 +32,7 @@
         </li>
       </Step>
       <Step
-        v-if="currentStep === 'broadcastChannelSelect'"
+        v-if="currentStep === 'channelSelect'"
         :class="'broadcast-channel-select-step'"
         :title="getStepTitle(currentStep)"
         :desciption="getStepDescription(currentStep)">

--- a/app/components/windows/NicoliveProgramSelector.vue
+++ b/app/components/windows/NicoliveProgramSelector.vue
@@ -1,35 +1,77 @@
 <template>
 <modal-layout
+  bare-content
   :title="$t('streaming.nicoliveProgramSelector.title')"
   :show-controls="false"
-  :custom-controls="true">
-  <div slot="content">
-    <p class="caption" v-html="$t('streaming.nicoliveProgramSelector.description')" />
-    <fieldset>
-      <ul class="program-list">
-        <li v-for="(info, key) in selectionInfo" :key="key" class="program">
-          <input type="radio" :id="key" :value="key" v-model="selectedId">
-          <label :for="key" class="program-infomation">
-            <p class="title">{{ info.title }}</p>
-            <p class="description">
-              <span class="lv">{{ key }}</span>
-              {{ info.description }}
-            </p>
-          </label>
+  :custom-controls="true"
+  >
+  <div slot="content" class="nicolive-program-selector">
+    <NavMenu v-model="currentStep" class="side-menu" data-test="SideMenu">
+      <NavItem
+        v-for="step in steps"
+        :enabled="shouldEnableNavItem(step)"
+        :key="step"
+        :to="step"
+        :ico=" isCompletedStep(step) ? 'icon-check' : undefined"
+        :data-test="step"
+      >
+        <h3>{{ getStepTitleForMenu(step) }}</h3>
+        <p v-if="isCompletedStep(step)">{{ getSelectedValueForDisplay(step) }}</p>
+      </NavItem>
+    </NavMenu>
+    <div class="nicolive-program-selector-container">
+      <Step
+        v-if="currentStep === 'providerTypeSelect'"
+        :class="'provider-type-select-step'"
+        :title="getStepTitle(currentStep)"
+        :desciption="getStepDescription(currentStep)">
+        <li v-for="providerType in providerTypes" :key="providerType">
+          <a @click="onSelectProviderType(providerType)">
+            <p class="anchor-text">{{ getProviderTypeProgramText(providerType) }}</p>
+          </a>
         </li>
-      </ul>
-    </fieldset>
+      </Step>
+      <Step
+        v-if="currentStep === 'broadcastChannelSelect'"
+        :class="'broadcast-channel-select-step'"
+        :title="getStepTitle(currentStep)"
+        :desciption="getStepDescription(currentStep)">
+          <li v-for="(channel, channelId) in queryParams.channels" :key="channelId" >
+            <a @click="onSelectChannel(channelId, channel.name)">
+              <img :src="channel.thumbnailUrl" :alt="channel.name" class="channel-thumbnail" />
+              <p class="anchor-text">{{ channel.name }}</p>
+            </a>
+          </li>
+      </Step>
+      <Step
+          v-if="currentStep === 'programSelect'"
+          :class="'program-select-step'"
+          :title="getStepTitle(currentStep)"
+          :desciption="getStepDescription(currentStep)">
+          <li v-for="program in candidatePrograms" :key="program.id">
+            <a @click="onSelectBroadcastingProgram(program.id, program.title)" >
+              <p class="anchor-text">{{ program.title }}</p>
+              <p class="annotation">
+                <span class="lv">{{ program.id }}</span>
+              </p>
+            </a>
+          </li>
+      </Step>
+      <Step
+        v-if="currentStep === 'confirm'"
+        :class="'confirm-step'"
+        :title="getStepTitle(currentStep)"
+        :desciption="getStepDescription(currentStep)">
+          <li v-for="step in selectionSteps" :key="step">
+            <div class="caption">{{ getStepTitle(step) }}</div>
+            <div class="value">{{ getSelectedValueForDisplay(step) || '-' }}</div>
+          </li>
+      </Step>
+    </div>
   </div>
-  <div slot="controls">
-    <button
-      class="button button--default"
-      @click="cancel"
-      data-test="Cancel">
-      {{ $t('streaming.nicoliveProgramSelector.cancel') }}
-    </button>
+  <div slot="controls" v-if="currentStep === 'confirm'">
     <button
       class="button button--action"
-      :disabled="disabledOk"
       @click="ok"
       data-test="Done">
       {{ $t('streaming.nicoliveProgramSelector.done') }}
@@ -42,135 +84,115 @@
 
 <style lang="less" scoped>
 @import "../../styles/_colors";
-.caption {
-  letter-spacing: .1em;
-  font-size: 18px;
-  font-style: normal;
-  text-align: center;
-  color: @text-primary;
-  margin-bottom: 16px;
+
+.nicolive-program-selector {
+  display: flex;
+  height: 100%;
 }
-.program-list {
+
+.side-menu {
+  overflow-y: auto;
+}
+
+.nicolive-program-selector-container {
+  margin: 0;
+  overflow-y: auto;
+  background-color: @bg-tertiary;
+  width: 100%;
+}
+
+.list {
   margin-left: 0;
-  width: 668px;
+  width: 100%;
   > li {
     list-style: none;
-  }
-}
-
-.program {
-  position: relative;
-  margin-bottom: 16px;
-  border-bottom: 2px solid @bg-secondary;
-  &:last-child {
-    border-bottom: none;
-  }
-
-  //ラジオボタン非選択時
-  label {
-    width: 100%;
-    display: block;
-    text-align: left;
-    margin-left: 0;
-    margin-right: 0;
-    cursor: pointer;
     position: relative;
-    z-index: 2;
-    transition: color 200ms ease-in;
-    overflow: hidden;
-    color: @text-secondary;
-    .title {
-      display: inline-block;
-      font-size: 16px;
-      text-indent: 1.3em;
-      margin-bottom: 0;
-      width: 100%;
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    border-bottom: 2px solid @bg-secondary;
+    &:hover {
+      background-color: @bg-secondary;
     }
-    .description {
-      display: inline-block;
-      font-size: 14px;
-      margin-bottom: 0;
-      width: 100%;
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      box-sizing: border-box;
-      .lv {
-        font-size: 12px;
-        background-color: @text-secondary;
-        color: @bg-primary;
-        border-radius: 2px;
-        padding: 2px 4px;
-      }
+    &:last-child {
+      border-bottom: none;
     }
-    &:before {
-      width: 16px;
-      height: 16px;
-      content: '';
-      border: 2px solid @grey;
-      background-color: rgba(145, 151, 154, .1);
-      border-radius: 50%;
+    > a {
+      width: 100%;
+      display: block;
+      text-align: left;
+      padding: 8px 0;
+      margin-left: 0;
+      margin-right: 0;
       cursor: pointer;
-      transition: all 200ms ease-in;
-      position: absolute;
-      left: 0;
-      top: 4px;
+      position: relative;
       z-index: 2;
-    }
-    &:after {
-      width: 6px;
-      height: 6px;
-      border-radius: 50%;
-      content: '';
-      background-color: @text-primary;
-      position: absolute;
-      left: 5px;
-      top: 9px;
-      transition: all 300ms cubic-bezier(0.4, 0.0, 0.2, 1);
-      opacity: 0;
-      z-index: 100;
-    }
-  }
-
-  //ラジオボタン選択時
-  input:checked ~ label {
-    .title {
-      color: @text-primary;
-    }
-    .description {
-      .lv {
-        color: @text-secondary;
+      transition: color 200ms ease-in;
+      overflow: hidden;
+      text-decoration: none;
+      color: @text-secondary;
+      .channel-thumbnail {
+        width: 36px;
+        height: 36px;
+        background-color: @bg-secondary;
+        overflow: hidden;
+        border-radius: 50%;
       }
-      .lv {
+      .anchor-text {
+        display: inline-block;
+        font-size: 16px;
+        text-indent: 1.3em;
+        margin-bottom: 0;
+        width: 80%;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        box-sizing: border-box;
+      }
+      .annotation {
+        display: inline-block;
+        font-size: 14px;
+        margin-bottom: 0;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        box-sizing: border-box;
+        .lv {
+          font-size: 12px;
+          background-color: @text-secondary;
+          color: @bg-primary;
+          border-radius: 2px;
+          padding: 2px 4px;
+        }
+      }
+      &:after {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        content: '';
         background-color: @text-primary;
-        color: @bg-primary;
+        position: absolute;
+        left: 5px;
+        top: 9px;
+        transition: all 300ms cubic-bezier(0.4, 0.0, 0.2, 1);
+        opacity: 0;
+        z-index: 100;
       }
     }
-    &:before {
-      border-color: @text-primary;
-      background-color: rgba(158, 234, 249, .1);
-    }
-    &:after {
-      opacity: 1;
-    }
-  }
-
-  input {
-    position: absolute;
-    left: 4px;
-    top: 4px;
-    z-index: 2;
-    margin-bottom: 0;
-    width: 16px;
-    height: 16px;
-    order: 1;
-    cursor: pointer;
-    visibility: hidden;
   }
 }
-
+.confirm-step {
+  ul {
+    > li {
+      font-size: 16px;
+      display: flex;
+      justify-content: space-around;
+      > .caption {
+        width: 30%;
+      }
+      > .value {
+        width: 60%;
+      }
+    }
+  }
+}
 </style>

--- a/app/components/windows/NicoliveProgramSelector.vue.ts
+++ b/app/components/windows/NicoliveProgramSelector.vue.ts
@@ -62,11 +62,8 @@ export default class NicoliveProgramSelector extends Vue {
     if (providerType === 'channel') {
       this.nicoliveProgramSelectorService.onSelectProviderTypeChannel();
     } else {
-      // 1つのコミュニティしかない前提
-      const communityId = Object.keys(this.queryParams.communities)[0];
       this.nicoliveProgramSelectorService.onSelectProviderTypeUser(
-        // 1つの番組しかない前提
-        this.queryParams.communities[communityId].broadcastablePrograms[0].id
+        this.queryParams.community.id
       );
     }
   }
@@ -75,8 +72,8 @@ export default class NicoliveProgramSelector extends Vue {
     if (this.nicoliveProgramSelectorService.state.isLoading) {
       return;
     }
-    this.nicoliveProgramSelectorService.onSelectChannel(
-      id, name, this.queryParams.channels[id].broadcastablePrograms);
+    const channel = this.queryParams.channels.find(channel => channel.id === id);
+    this.nicoliveProgramSelectorService.onSelectChannel(id, name, channel.broadcastablePrograms);
   }
 
   onSelectBroadcastingProgram(id: string, title: string): void {

--- a/app/components/windows/NicoliveProgramSelector.vue.ts
+++ b/app/components/windows/NicoliveProgramSelector.vue.ts
@@ -62,8 +62,11 @@ export default class NicoliveProgramSelector extends Vue {
     if (providerType === 'channel') {
       this.nicoliveProgramSelectorService.onSelectProviderTypeChannel();
     } else {
+      // 1つのコミュニティしかない前提
+      const communityId = Object.keys(this.queryParams.communities)[0];
       this.nicoliveProgramSelectorService.onSelectProviderTypeUser(
-        this.queryParams.user.broadcastableProgramId
+        // 1つの番組しかない前提
+        this.queryParams.communities[communityId].broadcastablePrograms[0].id
       );
     }
   }
@@ -73,7 +76,7 @@ export default class NicoliveProgramSelector extends Vue {
       return;
     }
     this.nicoliveProgramSelectorService.onSelectChannel(
-      id, name, this.queryParams.channels[id].broadcastableProgramIds);
+      id, name, this.queryParams.channels[id].broadcastablePrograms);
   }
 
   onSelectBroadcastingProgram(id: string, title: string): void {

--- a/app/components/windows/NicoliveProgramSelector.vue.ts
+++ b/app/components/windows/NicoliveProgramSelector.vue.ts
@@ -133,4 +133,9 @@ export default class NicoliveProgramSelector extends Vue {
 
     this.windowsService.closeChildWindow();
   }
+
+  beforeDestroy(): void {
+    // 状態初期化
+    this.nicoliveProgramSelectorService.backTo('providerTypeSelect');
+  }
 }

--- a/app/components/windows/NicoliveProgramSelector.vue.ts
+++ b/app/components/windows/NicoliveProgramSelector.vue.ts
@@ -103,7 +103,7 @@ export default class NicoliveProgramSelector extends Vue {
     switch (navItemStep) {
       case 'providerTypeSelect':
         return this.getProviderTypeProgramText(selectedProviderType) || this.BLANK;
-      case 'broadcastChannelSelect':
+      case 'channelSelect':
         return selectedChannel?.name || this.BLANK;
       case 'programSelect':
         return selectedProgram?.title || this.BLANK;

--- a/app/components/windows/NicoliveProgramSelector.vue.ts
+++ b/app/components/windows/NicoliveProgramSelector.vue.ts
@@ -2,38 +2,135 @@ import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 import { Inject } from 'util/injector';
 import ModalLayout from '../ModalLayout.vue';
+import NavMenu from '../shared/NavMenu.vue';
+import NavItem from '../shared/NavItem.vue';
+import Step from '../nicolive-program-selector/Step.vue';
 import windowMixin from '../mixins/window';
 import { WindowsService } from '../../services/windows';
-import { LiveProgramInfo } from 'services/platforms/niconico';
+import {
+  NicoliveProgramSelectorService,
+  TProviderType,
+  TStep,
+  providerTypes as _providerTypes,
+  steps as _steps,
+  selectionSteps as _selectionSteps,
+  TSelectionStep
+} from 'services/nicolive-program/nicolive-program-selector';
+import { LiveProgramInfo2 } from 'services/platforms/niconico';
 import { StreamingService } from 'services/streaming';
+import { $t } from 'services/i18n';
 
 @Component({
   components: {
-    ModalLayout
+    ModalLayout,
+    NavMenu,
+    NavItem,
+    Step
   },
   mixins: [windowMixin]
 })
 export default class NicoliveProgramSelector extends Vue {
+  @Inject() nicoliveProgramSelectorService: NicoliveProgramSelectorService;
   @Inject() windowsService: WindowsService;
   @Inject() streamingService: StreamingService;
 
-  selectionInfo = (this.windowsService.getChildWindowOptions().queryParams || {}) as LiveProgramInfo;
-  selectedId = '';
+  queryParams = this.windowsService.getChildWindowOptions().queryParams as LiveProgramInfo2;
 
-  get disabledOk() {
-    return this.selectedId === '';
+  readonly providerTypes = _providerTypes;
+  readonly steps = _steps;
+  readonly selectionSteps = _selectionSteps;
+  readonly BLANK = '-';
+
+  get currentStep() {
+    return this.nicoliveProgramSelectorService.state.currentStep;
   }
 
-  ok() {
-    if (this.disabledOk) {
+  // NavMenu の v-model に指定されている currentStep が NavItem の選択で書き換えられようとするときに呼ばれるセッタ
+  // ナビゲーション選択でステップを移動する場合は, 既に完了したステップに戻る場合
+  set currentStep(step: TStep) {
+    this.nicoliveProgramSelectorService.backTo(step);
+  }
+
+  get candidatePrograms() {
+    return this.nicoliveProgramSelectorService.state.candidatePrograms;
+  }
+
+  onSelectProviderType(providerType: TProviderType): void {
+    if (this.nicoliveProgramSelectorService.state.isLoading) {
       return;
     }
-    this.streamingService.toggleStreamingAsync({programId: this.selectedId});
-
-    this.windowsService.closeChildWindow();
+    if (providerType === 'channel') {
+      this.nicoliveProgramSelectorService.onSelectChannelProgram();
+    } else {
+      this.nicoliveProgramSelectorService.onSelectUserProgram(
+        this.queryParams.user.broadcastableProgramId
+      );
+    }
   }
 
-  cancel() {
+  onSelectChannel(id: string, name: string): void {
+    if (this.nicoliveProgramSelectorService.state.isLoading) {
+      return;
+    }
+    this.nicoliveProgramSelectorService.onSelectChannel(
+      id, name, this.queryParams.channels[id].broadcastableProgramIds);
+  }
+
+  onSelectBroadcastingProgram(id: string, title: string): void {
+    if (this.nicoliveProgramSelectorService.state.isLoading) {
+      return;
+    }
+    this.nicoliveProgramSelectorService.onSelectBroadcastingProgram(id, title);
+  }
+
+  isCompletedStep(step: TStep): boolean {
+    return this.nicoliveProgramSelectorService.isCompletedStep(step);
+  }
+
+  shouldEnableNavItem(step: TStep): boolean {
+    return (
+      !this.nicoliveProgramSelectorService.state.isLoading &&
+      this.nicoliveProgramSelectorService.isCompletedOrCurrentStep(step)
+    );
+  }
+
+  getSelectedValueForDisplay(navItemStep: TSelectionStep): string {
+    const {
+       selectedProviderType,
+       selectedChannel,
+       selectedProgram
+    } = this.nicoliveProgramSelectorService.state;
+    switch (navItemStep) {
+      case 'providerTypeSelect':
+        return this.getProviderTypeProgramText(selectedProviderType) || this.BLANK;
+      case 'broadcastChannelSelect':
+        return selectedChannel?.name || this.BLANK;
+      case 'programSelect':
+        return selectedProgram?.title || this.BLANK;
+    }
+  }
+
+  getProviderTypeProgramText(providerType: TProviderType): string {
+    return $t(`streaming.nicoliveProgramSelector.providerTypeProgram.${providerType}`);
+  }
+
+  getStepTitleForMenu(step: TStep): string {
+    return $t(`streaming.nicoliveProgramSelector.steps.${step}.menuTitle`);
+  }
+
+  getStepTitle(step: TStep): string {
+    return $t(`streaming.nicoliveProgramSelector.steps.${step}.title`);
+  }
+
+  getStepDescription(step: TStep): string {
+    return $t(`streaming.nicoliveProgramSelector.steps.${step}.desciption`);
+  }
+
+  ok(): void {
+    this.streamingService.toggleStreamingAsync({
+      programId: this.nicoliveProgramSelectorService.state.selectedProgram.id
+    });
+
     this.windowsService.closeChildWindow();
   }
 }

--- a/app/components/windows/NicoliveProgramSelector.vue.ts
+++ b/app/components/windows/NicoliveProgramSelector.vue.ts
@@ -60,9 +60,9 @@ export default class NicoliveProgramSelector extends Vue {
       return;
     }
     if (providerType === 'channel') {
-      this.nicoliveProgramSelectorService.onSelectChannelProgram();
+      this.nicoliveProgramSelectorService.onSelectProviderTypeChannel();
     } else {
-      this.nicoliveProgramSelectorService.onSelectUserProgram(
+      this.nicoliveProgramSelectorService.onSelectProviderTypeUser(
         this.queryParams.user.broadcastableProgramId
       );
     }

--- a/app/i18n/en-US/streaming.json
+++ b/app/i18n/en-US/streaming.json
@@ -47,7 +47,7 @@
         "title": "",
         "description": ""
       },
-      "broadcastChannelSelect": {
+      "channelSelect": {
         "menuTitle": "",
         "title": "",
         "description": ""

--- a/app/i18n/en-US/streaming.json
+++ b/app/i18n/en-US/streaming.json
@@ -41,6 +41,32 @@
     "title": "Select a programs to start streaming on",
     "description": "There is more than one candidate program.<br/>Select one of the programs to start streaming on.",
     "cancel": "Cancel",
+    "steps": {
+      "providerTypeSelect": {
+        "menuTitle": "",
+        "title": "",
+        "description": ""
+      },
+      "broadcastChannelSelect": {
+        "menuTitle": "",
+        "title": "",
+        "description": ""
+      },
+      "programSelect": {
+        "menuTitle": "",
+        "title":"",
+        "description": ""
+      },
+      "confirm": {
+        "menuTitle": "",
+        "title": "",
+        "description": ""
+      }
+    },
+    "providerTypeProgram": {
+      "channel": "",
+      "user": ""
+    },
     "done": "Select a program"
   },
   "FPS": "FPS",

--- a/app/i18n/ja-JP/streaming.json
+++ b/app/i18n/ja-JP/streaming.json
@@ -38,10 +38,36 @@
     "description": "ニコニコ生放送に最適化した設定で配信します。"
   },
   "nicoliveProgramSelector": {
-    "title": "配信する番組の選択",
+    "title": "配信番組の選択",
     "description": "配信可能な番組が複数あります。<br/>配信する番組を選択してください。",
     "cancel": "キャンセル",
-    "done": "配信する番組を決定する"
+    "steps": {
+      "providerTypeSelect": {
+        "menuTitle": "配信種別",
+        "title": "配信種別を選択",
+        "description": "配信する番組種別を選択してください。"
+      },
+      "broadcastChannelSelect": {
+        "menuTitle": "配信チャンネル",
+        "title": "配信チャンネルを選択",
+        "description": "リストから配信したいチャンネルを選択してください。"
+      },
+      "programSelect": {
+        "menuTitle": "配信番組択",
+        "title":"配信番組を選択",
+        "description": "配信を開始する番組を選択してください。"
+      },
+      "confirm": {
+        "menuTitle": "確認",
+        "title": "確認",
+        "description": "下記の内容で配信を開始します。"
+      }
+    },
+    "providerTypeProgram": {
+      "channel": "チャンネル番組",
+      "user": "ユーザー番組"
+    },
+    "done": "番組を決定して配信する"
   },
   "FPS": "フレームレート",
   "resolution": "解像度",

--- a/app/i18n/ja-JP/streaming.json
+++ b/app/i18n/ja-JP/streaming.json
@@ -47,7 +47,7 @@
         "title": "配信種別を選択",
         "description": "配信する番組種別を選択してください。"
       },
-      "broadcastChannelSelect": {
+      "channelSelect": {
         "menuTitle": "配信チャンネル",
         "title": "配信チャンネルを選択",
         "description": "リストから配信したいチャンネルを選択してください。"

--- a/app/services-manager.ts
+++ b/app/services-manager.ts
@@ -61,6 +61,7 @@ import { InformationsService } from 'services/informations';
 import { InformationsStateService } from 'services/informations/state';
 import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
 import { NicoliveProgramStateService } from 'services/nicolive-program/state';
+import { NicoliveProgramSelectorService } from 'services/nicolive-program/nicolive-program-selector';
 import { NicoliveCommentViewerService } from 'services/nicolive-program/nicolive-comment-viewer';
 import { NicoliveCommentFilterService } from 'services/nicolive-program/nicolive-comment-filter';
 import { NicoliveCommentLocalFilterService } from 'services/nicolive-program/nicolive-comment-local-filter';
@@ -130,6 +131,7 @@ export class ServicesManager extends Service {
     InformationsStateService,
     NicoliveProgramService,
     NicoliveProgramStateService,
+    NicoliveProgramSelectorService,
     NicoliveCommentViewerService,
     NicoliveCommentFilterService,
     NicoliveCommentLocalFilterService,

--- a/app/services/nicolive-program/nicolive-program-selector.test.ts
+++ b/app/services/nicolive-program/nicolive-program-selector.test.ts
@@ -48,14 +48,14 @@ test('チャンネル番組を選んで配信開始のための番組情報を�
   // 番組選択へ
   const selectedChannelId = 'ch9999';
   const selectedChannelName = 'チャンネルああああ'
-  const programIds = ['lv1111', 'lv2222'];
-  instance.onSelectChannel(selectedChannelId, selectedChannelName, programIds);
+  const programs = [{ id: 'lv1111' }, { id: 'lv2222' }];
+  instance.onSelectChannel(selectedChannelId, selectedChannelName, programs);
   expect(instance.state.currentStep).toBe('programSelect');
   // TODO: APIを叩くようになったら、モック化されたAPIを絡めたテストを書く
   // その際タイトルも検査するようにする
   expect(instance.state.selectedChannel).toMatchObject({ id: selectedChannelId, name: selectedChannelName })
-  expect(instance.state.candidatePrograms[0].id).toBe(programIds[0]);
-  expect(instance.state.candidatePrograms[1].id).toBe(programIds[1]);
+  expect(instance.state.candidatePrograms[0].id).toBe(programs[0].id);
+  expect(instance.state.candidatePrograms[1].id).toBe(programs[1].id);
 
   // 確認へ
   const selectedProgramId = 'lv1111';
@@ -122,7 +122,7 @@ test('番組選択ステップで, 配信種別やチャンネルの選択をし
 
   // 番組選択へ
   const selectedChannelId = 'ch9999';
-  instance.onSelectChannel(selectedChannelId, 'チャンネルああああ', ['lv1111', 'lv2222']);
+  instance.onSelectChannel(selectedChannelId, 'チャンネルああああ', [{ id: 'lv1111' }, { id: 'lv2222' }]);
   expect(instance.state.currentStep).toBe('programSelect');
 
   // 配信種別をチャンネルに変更しようとしても何も起きない
@@ -184,7 +184,7 @@ test('チャンネル番組の確認ステップでは, あらゆる設定済の
 
   // 番組選択へ
   const selectedChannelId = 'ch9999';
-  instance.onSelectChannel(selectedChannelId, 'チャンネルああああ', ['lv1111', 'lv2222']);
+  instance.onSelectChannel(selectedChannelId, 'チャンネルああああ', [{ id: 'lv1111' }, { id: 'lv2222' }]);
 
   // 確認へ
   const selectedProgram = 'lv1111';
@@ -240,11 +240,11 @@ describe('ステップ比較系メソッド', () => {
           return instance;
         case 'programSelect':
           instance.onSelectProviderTypeChannel();
-          instance.onSelectChannel('ch9999', 'name', ['lv1', 'lv2', 'lv3']);
+          instance.onSelectChannel('ch9999', 'name', [{ id: 'lv1' }, { id: 'lv2' }, { id: 'lv3' }]);
           return instance;
         case 'confirm':
           instance.onSelectProviderTypeChannel();
-          instance.onSelectChannel('ch9999', 'name', ['lv1', 'lv2', 'lv3']);
+          instance.onSelectChannel('ch9999', 'name', [{ id: 'lv1' }, { id: 'lv2' }, { id: 'lv3' }]);
           instance.onSelectBroadcastingProgram('id', 'title');
           return instance;
       }
@@ -419,12 +419,12 @@ describe('ステップ比較系メソッド', () => {
           currentStep: 'programSelect',
           candidatePrograms: [
             // TODO: 番組情報取得APIを叩くようになったらそのAPIのモックの値に変更する必要がある
-            {id: 'lv1', title: 'これは lv1 のタイトルです'},
-            {id: 'lv2', title: 'これは lv2 のタイトルです'},
-            {id: 'lv3', title: 'これは lv3 のタイトルです'}
+            { id: 'lv1', title: 'これは lv1 のタイトルです' },
+            { id: 'lv2', title: 'これは lv2 のタイトルです' },
+            { id: 'lv3', title: 'これは lv3 のタイトルです' }
           ],
           selectedProviderType: 'channel',
-          selectedChannel: { id: 'ch9999', name: 'name'},
+          selectedChannel: { id: 'ch9999', name: 'name' },
           selectedProgram: null
         });
       });

--- a/app/services/nicolive-program/nicolive-program-selector.test.ts
+++ b/app/services/nicolive-program/nicolive-program-selector.test.ts
@@ -1,0 +1,461 @@
+import { createSetupFunction } from 'util/test-setup';
+import { Subject } from 'rxjs';
+import { NicoliveProgramSelectorService, TStep, TProviderType } from './nicolive-program-selector';
+
+const setup = createSetupFunction({
+  injectee: {
+    NicoliveProgramSelectorService: {
+      stateChange: new Subject(),
+    },
+  },
+});
+
+beforeEach(() => {
+  jest.doMock('services/stateful-service');
+  jest.doMock('util/injector');
+});
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+test('ユーザー番組を選んで配信開始のための番組情報を準備できる', () => {
+  setup();
+  const { NicoliveProgramSelectorService } = require('./nicolive-program-selector');
+  const instance = NicoliveProgramSelectorService.instance as NicoliveProgramSelectorService;
+  expect(instance.state.currentStep).toBe('providerTypeSelect');
+
+  // 確認へ
+  const programId = 'lv1111';
+  instance.onSelectUserProgram(programId);
+  expect(instance.state.currentStep).toBe('confirm');
+  expect(instance.state.selectedProviderType).toBe('user');
+  expect(instance.state.selectedChannel).toBeNull();
+  expect(instance.state.selectedProgram).toMatchObject({ id: programId });
+});
+
+test('チャンネル番組を選んで配信開始のための番組情報を準備できる', () => {
+  setup();
+  const { NicoliveProgramSelectorService } = require('./nicolive-program-selector');
+  const instance = NicoliveProgramSelectorService.instance as NicoliveProgramSelectorService;
+  expect(instance.state.currentStep).toBe('providerTypeSelect');
+
+  // チャンネル選択へ
+  instance.onSelectChannelProgram();
+  expect(instance.state.currentStep).toBe('broadcastChannelSelect');
+  expect(instance.state.selectedProviderType).toBe('channel');
+
+  // 番組選択へ
+  const selectedChannelId = 'ch9999';
+  const selectedChannelName = 'チャンネルああああ'
+  const programIds = ['lv1111', 'lv2222'];
+  instance.onSelectChannel(selectedChannelId, selectedChannelName, programIds);
+  expect(instance.state.currentStep).toBe('programSelect');
+  // TODO: APIを叩くようになったら、モック化されたAPIを絡めたテストを書く
+  // その際タイトルも検査するようにする
+  expect(instance.state.selectedChannel).toMatchObject({ id: selectedChannelId, name: selectedChannelName })
+  expect(instance.state.candidatePrograms[0].id).toBe(programIds[0]);
+  expect(instance.state.candidatePrograms[1].id).toBe(programIds[1]);
+
+  // 確認へ
+  const selectedProgramId = 'lv1111';
+  const selectedProgramTitle = '番組いいいい';
+  instance.onSelectBroadcastingProgram(selectedProgramId, selectedProgramTitle);
+  expect(instance.state.currentStep).toBe('confirm');
+  expect(instance.state.selectedProviderType).toBe('channel');
+  expect(instance.state.selectedChannel).toMatchObject({ id: selectedChannelId, name: selectedChannelName });
+  expect(instance.state.selectedProgram).toMatchObject({ id: selectedProgramId, title: selectedProgramTitle });
+});
+
+test('番組選択ステップで, チャンネルや番組の選択をしようとしても何も起きない.', () => {
+  setup();
+  const { NicoliveProgramSelectorService } = require('./nicolive-program-selector');
+  const instance = NicoliveProgramSelectorService.instance as NicoliveProgramSelectorService;
+  expect(instance.state.currentStep).toBe('providerTypeSelect');
+
+  // チャンネル選択ができない
+  instance.onSelectChannel('ch1', 'name', []);
+  expect(instance.state.currentStep).toBe('providerTypeSelect');
+  expect(instance.state.selectedChannel).toBeNull();
+
+  // 番組選択ができない
+  instance.onSelectBroadcastingProgram('lv1', 'title')
+  expect(instance.state.currentStep).toBe('providerTypeSelect');
+  expect(instance.state.selectedProgram).toBeNull();
+});
+
+test('チャンネル選択ステップで, 配信種別や番組の選択をしようとしても何も起きない. ', () => {
+  setup();
+  const { NicoliveProgramSelectorService } = require('./nicolive-program-selector');
+  const instance = NicoliveProgramSelectorService.instance as NicoliveProgramSelectorService;
+  expect(instance.state.currentStep).toBe('providerTypeSelect');
+
+  // チャンネル選択へ
+  instance.onSelectChannelProgram();
+  expect(instance.state.currentStep).toBe('broadcastChannelSelect');
+  expect(instance.state.selectedProviderType).toBe('channel');
+
+  // 配信種別をチャンネルに変更しようとしても何も起きない
+  instance.onSelectChannelProgram();
+  expect(instance.state.currentStep).toBe('broadcastChannelSelect');
+  expect(instance.state.selectedProviderType).toBe('channel');
+
+  // 配信種別をユーザー番組に変更できない
+  instance.onSelectUserProgram('lv1');
+  expect(instance.state.currentStep).toBe('broadcastChannelSelect');
+  expect(instance.state.selectedProviderType).toBe('channel');
+
+  // 番組を選択できない
+  instance.onSelectBroadcastingProgram('lv1', 'title')
+  expect(instance.state.currentStep).toBe('broadcastChannelSelect');
+  expect(instance.state.selectedProgram).toBeNull();
+});
+
+test('番組選択ステップで, 配信種別やチャンネルの選択をしようとしても何も起きない.', () => {
+  setup();
+  const { NicoliveProgramSelectorService } = require('./nicolive-program-selector');
+  const instance = NicoliveProgramSelectorService.instance as NicoliveProgramSelectorService;
+  expect(instance.state.currentStep).toBe('providerTypeSelect');
+
+  // チャンネル選択へ
+  instance.onSelectChannelProgram();
+
+  // 番組選択へ
+  const selectedChannelId = 'ch9999';
+  instance.onSelectChannel(selectedChannelId, 'チャンネルああああ', ['lv1111', 'lv2222']);
+  expect(instance.state.currentStep).toBe('programSelect');
+
+  // 配信種別をチャンネルに変更しようとしても何も起きない
+  instance.onSelectChannelProgram();
+  expect(instance.state.currentStep).toBe('programSelect');
+  expect(instance.state.selectedProviderType).toBe('channel');
+
+  // 配信種別をユーザー番組に変更できない
+  instance.onSelectUserProgram('lv1');
+  expect(instance.state.currentStep).toBe('programSelect');
+  expect(instance.state.selectedProviderType).toBe('channel');
+
+  // チャンネルを選択しようとしても何も起きない
+  instance.onSelectChannel('ch100000000', 'name', [])
+  expect(instance.state.currentStep).toBe('programSelect');
+  expect(instance.state.selectedChannel.id).toBe(selectedChannelId)
+});
+
+test('ユーザー番組の確認ステップでは, あらゆる設定済の項目を変更することはできない.', () => {
+  setup();
+  const { NicoliveProgramSelectorService } = require('./nicolive-program-selector');
+  const instance = NicoliveProgramSelectorService.instance as NicoliveProgramSelectorService;
+  expect(instance.state.currentStep).toBe('providerTypeSelect');
+
+  // 確認へ
+  instance.onSelectUserProgram('lv9800');
+  expect(instance.state.currentStep).toBe('confirm');
+
+  // 配信種別をチャンネルに変更できない
+  instance.onSelectChannelProgram();
+  expect(instance.state.currentStep).toBe('confirm');
+  expect(instance.state.selectedProviderType).toBe('user');
+
+  // 配信種別をユーザーに変更しようとしても何も起きない
+  instance.onSelectChannelProgram();
+  expect(instance.state.currentStep).toBe('confirm');
+  expect(instance.state.selectedProviderType).toBe('user');
+
+  // チャンネルを選択しようとしても何も起きない
+  instance.onSelectChannel('ch1111', 'name', [])
+  expect(instance.state.currentStep).toBe('confirm');
+  expect(instance.state.selectedProviderType).toBe('user');
+  expect(instance.state.selectedChannel).toBeNull();
+
+  // 番組を選択しようとしても変更できない
+  instance.onSelectBroadcastingProgram('lv1111', 'title')
+  expect(instance.state.currentStep).toBe('confirm');
+  expect(instance.state.selectedProviderType).toBe('user');
+  expect(instance.state.selectedProgram.id).toBe('lv9800');
+});
+
+test('チャンネル番組の確認ステップでは, あらゆる設定済の項目を変更することはできない', () => {
+  setup();
+  const { NicoliveProgramSelectorService } = require('./nicolive-program-selector');
+  const instance = NicoliveProgramSelectorService.instance as NicoliveProgramSelectorService;
+  expect(instance.state.currentStep).toBe('providerTypeSelect');
+  // チャンネル選択へ
+  instance.onSelectChannelProgram();
+
+  // 番組選択へ
+  const selectedChannelId = 'ch9999';
+  instance.onSelectChannel(selectedChannelId, 'チャンネルああああ', ['lv1111', 'lv2222']);
+
+  // 確認へ
+  const selectedProgram = 'lv1111';
+  instance.onSelectBroadcastingProgram(selectedProgram, 'タイトル');
+  expect(instance.state.currentStep).toBe('confirm');
+
+  // 配信種別をチャンネルに変更しようとしても何も起きない
+  instance.onSelectChannelProgram();
+  expect(instance.state.currentStep).toBe('confirm');
+  expect(instance.state.selectedProviderType).toBe('channel');
+
+  // 配信種別をユーザーに変更できない
+  instance.onSelectChannelProgram();
+  expect(instance.state.currentStep).toBe('confirm');
+  expect(instance.state.selectedProviderType).toBe('channel');
+
+  // チャンネルを選択しようとしても変更できない
+  instance.onSelectChannel('ch1111', 'name', [])
+  expect(instance.state.currentStep).toBe('confirm');
+  expect(instance.state.selectedProviderType).toBe('channel');
+  expect(instance.state.selectedChannel.id).toBe(selectedChannelId);
+
+  // 番組を選択しようとしても変更できない
+  instance.onSelectBroadcastingProgram('lv2222', 'title')
+  expect(instance.state.currentStep).toBe('confirm');
+  console.log(instance.state.currentStep);
+  expect(instance.state.selectedProviderType).toBe('channel');
+  expect(instance.state.selectedProgram.id).toBe(selectedProgram);
+});
+
+describe('ステップ比較系メソッド', () => {
+  // 指定ステップの状態のインスタンスを作るユーティリティ
+  function createServiceInstanceByStep(step: TStep, providerType: TProviderType) {
+    setup();
+    const { NicoliveProgramSelectorService } = require('./nicolive-program-selector');
+    const instance = NicoliveProgramSelectorService.instance as NicoliveProgramSelectorService;
+    if (providerType === 'user') {
+      switch (step) {
+        case 'providerTypeSelect':
+          return instance;
+        case 'confirm':
+          instance.onSelectUserProgram('id');
+          return instance;
+        default:
+          throw new Error('作れません')
+      }
+    } else {
+      switch (step) {
+        case 'providerTypeSelect':
+          return instance;
+        case 'broadcastChannelSelect':
+          instance.onSelectChannelProgram();
+          return instance;
+        case 'programSelect':
+          instance.onSelectChannelProgram();
+          instance.onSelectChannel('ch9999', 'name', ['lv1', 'lv2', 'lv3']);
+          return instance;
+        case 'confirm':
+          instance.onSelectChannelProgram();
+          instance.onSelectChannel('ch9999', 'name', ['lv1', 'lv2', 'lv3']);
+          instance.onSelectBroadcastingProgram('id', 'title');
+          return instance;
+      }
+    }
+  }
+  describe('isCompletedOrCurrentStep', () => {
+    test('providerTypeSelect ステップのインスタンスに対して正しい値を返す', () => {
+      // 初期状態なので, 'user' でも同様.
+      const instance = createServiceInstanceByStep('providerTypeSelect', 'channel');
+      expect(instance.isCompletedOrCurrentStep('providerTypeSelect')).toBe(true);
+      expect(instance.isCompletedOrCurrentStep('broadcastChannelSelect')).toBe(false);
+      expect(instance.isCompletedOrCurrentStep('programSelect')).toBe(false);
+      expect(instance.isCompletedOrCurrentStep('confirm')).toBe(false);
+    });
+    test('broadcastChannelSelect ステップのインスタンスに対して正しい値を返す', () => {
+      const instance = createServiceInstanceByStep('broadcastChannelSelect', 'channel');
+      expect(instance.isCompletedOrCurrentStep('providerTypeSelect')).toBe(true);
+      expect(instance.isCompletedOrCurrentStep('broadcastChannelSelect')).toBe(true);
+      expect(instance.isCompletedOrCurrentStep('programSelect')).toBe(false);
+      expect(instance.isCompletedOrCurrentStep('confirm')).toBe(false);
+    });
+    test('programSelect ステップのインスタンスに対して正しい値を返す', () => {
+      const instance = createServiceInstanceByStep('programSelect', 'channel');
+      expect(instance.isCompletedOrCurrentStep('providerTypeSelect')).toBe(true);
+      expect(instance.isCompletedOrCurrentStep('broadcastChannelSelect')).toBe(true);
+      expect(instance.isCompletedOrCurrentStep('programSelect')).toBe(true);
+      expect(instance.isCompletedOrCurrentStep('confirm')).toBe(false);
+    });
+    test('confirm ステップ (チャンネル番組) のインスタンスに対して正しい値を返す', () => {
+      const instance = createServiceInstanceByStep('confirm', 'channel');
+      expect(instance.isCompletedOrCurrentStep('providerTypeSelect')).toBe(true);
+      expect(instance.isCompletedOrCurrentStep('broadcastChannelSelect')).toBe(true);
+      expect(instance.isCompletedOrCurrentStep('programSelect')).toBe(true);
+      expect(instance.isCompletedOrCurrentStep('confirm')).toBe(true);
+    });
+    test('confirm ステップ (ユーザー番組) のインスタンスに対して正しい値を返す', () => {
+      const instance = createServiceInstanceByStep('confirm', 'user');
+      expect(instance.isCompletedOrCurrentStep('providerTypeSelect')).toBe(true);
+      expect(instance.isCompletedOrCurrentStep('broadcastChannelSelect')).toBe(false); // ユーザー番組は経由しない
+      expect(instance.isCompletedOrCurrentStep('programSelect')).toBe(false); // ユーザー番組は経由しない
+    });
+  });
+  describe('isCompletedStep', () => {
+    test('providerTypeSelect ステップのインスタンスに対して正しい値を返す', () => {
+      // 初期状態なので, 'user' でも同様.
+      const instance = createServiceInstanceByStep('providerTypeSelect', 'channel');
+      expect(instance.isCompletedStep('providerTypeSelect')).toBe(false);
+      expect(instance.isCompletedStep('broadcastChannelSelect')).toBe(false);
+      expect(instance.isCompletedStep('programSelect')).toBe(false);
+      expect(instance.isCompletedStep('confirm')).toBe(false);
+    });
+    test('broadcastChannelSelect ステップのインスタンスに対して正しい値を返す', () => {
+      const instance = createServiceInstanceByStep('broadcastChannelSelect', 'channel');
+      expect(instance.isCompletedStep('providerTypeSelect')).toBe(true);
+      expect(instance.isCompletedStep('broadcastChannelSelect')).toBe(false);
+      expect(instance.isCompletedStep('programSelect')).toBe(false);
+      expect(instance.isCompletedStep('confirm')).toBe(false);
+    });
+    test('programSelect ステップのインスタンスに対して正しい値を返す', () => {
+      const instance = createServiceInstanceByStep('programSelect', 'channel');
+      expect(instance.isCompletedStep('providerTypeSelect')).toBe(true);
+      expect(instance.isCompletedStep('broadcastChannelSelect')).toBe(true);
+      expect(instance.isCompletedStep('programSelect')).toBe(false);
+      expect(instance.isCompletedStep('confirm')).toBe(false);
+    });
+    test('confirm ステップ (チャンネル番組) のインスタンスに対して正しい値を返す', () => {
+      const instance = createServiceInstanceByStep('confirm', 'channel');
+      expect(instance.isCompletedStep('providerTypeSelect')).toBe(true);
+      expect(instance.isCompletedStep('broadcastChannelSelect')).toBe(true);
+      expect(instance.isCompletedStep('programSelect')).toBe(true);
+      expect(instance.isCompletedStep('confirm')).toBe(false);
+    });
+    test('confirm ステップ (ユーザー番組) のインスタンスに対して正しい値を返す', () => {
+      const instance = createServiceInstanceByStep('confirm', 'user');
+      expect(instance.isCompletedStep('providerTypeSelect')).toBe(true);
+      expect(instance.isCompletedStep('broadcastChannelSelect')).toBe(false); // ユーザー番組は経由しない
+      expect(instance.isCompletedStep('programSelect')).toBe(false); // ユーザー番組は経由しない
+      expect(instance.isCompletedStep('confirm')).toBe(false);
+    });
+  });
+  describe('backTo', () => {
+    describe('providerTypeSelect ステップのインスタンスに対して呼び出しても何も起こらない', () => {
+      test('どの状態に戻ろうとしても何も起こらない', () => {
+        const instance = createServiceInstanceByStep('providerTypeSelect', 'channel');
+        (instance as any).SET_STATE = jest.fn();
+        instance.backTo('providerTypeSelect');
+        instance.backTo('broadcastChannelSelect');
+        instance.backTo('programSelect');
+        instance.backTo('confirm');
+        expect((instance as any).SET_STATE).not.toBeCalled();
+      })
+    });
+    describe('broadcastChanelSelect ステップのインスタンスに対して状態をクリアできる', () => {
+      test('providerTypeSelect ステップに戻るときに適切な状態に初期化できる', () => {
+        const instance = createServiceInstanceByStep('broadcastChannelSelect', 'channel');
+        instance.backTo('providerTypeSelect');
+        expect(instance.state).toMatchObject({
+          currentStep: 'providerTypeSelect',
+          candidatePrograms: [],
+          selectedProviderType: null,
+          selectedChannel: null,
+          selectedProgram: null
+        });
+      });
+      test('その他のステップに戻ろうとしても何も起こらない', () => {
+        const instance = createServiceInstanceByStep('broadcastChannelSelect', 'channel');
+        (instance as any).SET_STATE = jest.fn();
+        instance.backTo('broadcastChannelSelect');
+        instance.backTo('programSelect');
+        instance.backTo('confirm');
+        expect((instance as any).SET_STATE).not.toBeCalled();
+      })
+    });
+    describe('programSelect ステップのインスタンスに対して状態をクリアできる', () => {
+      test('providerTypeSelect ステップに戻るときに適切な状態に初期化できる', () => {
+        const instance = createServiceInstanceByStep('programSelect', 'channel');
+        instance.backTo('providerTypeSelect');
+        expect(instance!.state).toMatchObject({
+          currentStep: 'providerTypeSelect',
+          candidatePrograms: [],
+          selectedProviderType: null,
+          selectedChannel: null,
+          selectedProgram: null
+        });
+      });
+      test('broadcastChannelSelect ステップに戻るときに適切な状態に初期化できる', () => {
+        const instance = createServiceInstanceByStep('programSelect', 'channel');
+        instance.backTo('broadcastChannelSelect');
+        expect(instance.state).toMatchObject({
+          currentStep: 'broadcastChannelSelect',
+          candidatePrograms: [],
+          selectedProviderType: 'channel',
+          selectedChannel: null,
+          selectedProgram: null
+        });
+      });
+      test('その他のステップに戻ろうとしても何も起こらない', () => {
+        const instance = createServiceInstanceByStep('programSelect', 'channel');
+        (instance as any).SET_STATE = jest.fn();
+        instance.backTo('programSelect');
+        instance.backTo('confirm');
+        expect((instance as any).SET_STATE).not.toBeCalled();
+      });
+    });
+    describe('confirm ステップ (チャンネル番組) のインスタンスに対して状態をクリアできる', () => {
+      test('providerTypeSelect ステップに戻るときに適切な状態に初期化できる', () => {
+        const instance = createServiceInstanceByStep('confirm', 'channel');
+        instance.backTo('providerTypeSelect');
+        expect(instance.state).toMatchObject({
+          currentStep: 'providerTypeSelect',
+          candidatePrograms: [],
+          selectedProviderType: null,
+          selectedChannel: null,
+          selectedProgram: null
+        });
+      });
+      test('broadcastChannelSelect ステップに戻るときに適切な状態に初期化できる', () => {
+        const instance = createServiceInstanceByStep('confirm', 'channel');
+        instance.backTo('broadcastChannelSelect');
+        expect(instance.state).toMatchObject({
+          currentStep: 'broadcastChannelSelect',
+          candidatePrograms: [],
+          selectedProviderType: 'channel',
+          selectedChannel: null,
+          selectedProgram: null
+        });
+      });
+      test('programSelect ステップに戻るときに適切な状態に初期化できる', () => {
+        const instance = createServiceInstanceByStep('confirm', 'channel');
+        instance.backTo('programSelect');
+        expect(instance.state).toMatchObject({
+          currentStep: 'programSelect',
+          candidatePrograms: [
+            // TODO: 番組情報取得APIを叩くようになったらそのAPIのモックの値に変更する必要がある
+            {id: 'lv1', title: 'これは lv1 のタイトルです'},
+            {id: 'lv2', title: 'これは lv2 のタイトルです'},
+            {id: 'lv3', title: 'これは lv3 のタイトルです'}
+          ],
+          selectedProviderType: 'channel',
+          selectedChannel: { id: 'ch9999', name: 'name'},
+          selectedProgram: null
+        });
+      });
+      test('confirm ステップに戻ろうとしても何も起こらない', () => {
+        const instance = createServiceInstanceByStep('confirm', 'channel');
+        (instance as any).SET_STATE = jest.fn();
+        instance.backTo('confirm');
+        expect((instance as any).SET_STATE).not.toBeCalled();
+      });
+    });
+    describe('confirm ステップ (ユーザー番組) のインスタンスに対して状態をクリアできる', () => {
+      test('providerTypeSelect ステップに戻るときに適切な状態に初期化できる', () => {
+        const instance = createServiceInstanceByStep('confirm', 'user');
+        instance.backTo('providerTypeSelect');
+        expect(instance.state).toMatchObject({
+          currentStep: 'providerTypeSelect',
+          candidatePrograms: [],
+          selectedProviderType: null,
+          selectedChannel: null,
+          selectedProgram: null
+        });
+      });
+      test('他のステップに戻ろうとしても何も起こらない', () => {
+        const instance = createServiceInstanceByStep('confirm', 'user');
+        (instance as any).SET_STATE = jest.fn();
+        instance.backTo('broadcastChannelSelect'); // ユーザー番組ではスキップされるため無効
+        instance.backTo('programSelect');  // ユーザー番組ではスキップされるため無効
+        instance.backTo('confirm');
+        expect((instance as any).SET_STATE).not.toBeCalled();
+      });
+    });
+  })
+})
+

--- a/app/services/nicolive-program/nicolive-program-selector.test.ts
+++ b/app/services/nicolive-program/nicolive-program-selector.test.ts
@@ -42,7 +42,7 @@ test('チャンネル番組を選んで配信開始のための番組情報を�
 
   // チャンネル選択へ
   instance.onSelectProviderTypeChannel();
-  expect(instance.state.currentStep).toBe('broadcastChannelSelect');
+  expect(instance.state.currentStep).toBe('channelSelect');
   expect(instance.state.selectedProviderType).toBe('channel');
 
   // 番組選択へ
@@ -92,22 +92,22 @@ test('チャンネル選択ステップで, 配信種別や番組の選択をし
 
   // チャンネル選択へ
   instance.onSelectProviderTypeChannel();
-  expect(instance.state.currentStep).toBe('broadcastChannelSelect');
+  expect(instance.state.currentStep).toBe('channelSelect');
   expect(instance.state.selectedProviderType).toBe('channel');
 
   // 配信種別をチャンネルに変更しようとしても何も起きない
   instance.onSelectProviderTypeChannel();
-  expect(instance.state.currentStep).toBe('broadcastChannelSelect');
+  expect(instance.state.currentStep).toBe('channelSelect');
   expect(instance.state.selectedProviderType).toBe('channel');
 
   // 配信種別をユーザー番組に変更できない
   instance.onSelectProviderTypeUser('lv1');
-  expect(instance.state.currentStep).toBe('broadcastChannelSelect');
+  expect(instance.state.currentStep).toBe('channelSelect');
   expect(instance.state.selectedProviderType).toBe('channel');
 
   // 番組を選択できない
   instance.onSelectBroadcastingProgram('lv1', 'title')
-  expect(instance.state.currentStep).toBe('broadcastChannelSelect');
+  expect(instance.state.currentStep).toBe('channelSelect');
   expect(instance.state.selectedProgram).toBeNull();
 });
 
@@ -235,7 +235,7 @@ describe('ステップ比較系メソッド', () => {
       switch (step) {
         case 'providerTypeSelect':
           return instance;
-        case 'broadcastChannelSelect':
+        case 'channelSelect':
           instance.onSelectProviderTypeChannel();
           return instance;
         case 'programSelect':
@@ -255,35 +255,35 @@ describe('ステップ比較系メソッド', () => {
       // 初期状態なので, 'user' でも同様.
       const instance = createServiceInstanceByStep('providerTypeSelect', 'channel');
       expect(instance.isCompletedOrCurrentStep('providerTypeSelect')).toBe(true);
-      expect(instance.isCompletedOrCurrentStep('broadcastChannelSelect')).toBe(false);
+      expect(instance.isCompletedOrCurrentStep('channelSelect')).toBe(false);
       expect(instance.isCompletedOrCurrentStep('programSelect')).toBe(false);
       expect(instance.isCompletedOrCurrentStep('confirm')).toBe(false);
     });
-    test('broadcastChannelSelect ステップのインスタンスに対して正しい値を返す', () => {
-      const instance = createServiceInstanceByStep('broadcastChannelSelect', 'channel');
+    test('channelSelect ステップのインスタンスに対して正しい値を返す', () => {
+      const instance = createServiceInstanceByStep('channelSelect', 'channel');
       expect(instance.isCompletedOrCurrentStep('providerTypeSelect')).toBe(true);
-      expect(instance.isCompletedOrCurrentStep('broadcastChannelSelect')).toBe(true);
+      expect(instance.isCompletedOrCurrentStep('channelSelect')).toBe(true);
       expect(instance.isCompletedOrCurrentStep('programSelect')).toBe(false);
       expect(instance.isCompletedOrCurrentStep('confirm')).toBe(false);
     });
     test('programSelect ステップのインスタンスに対して正しい値を返す', () => {
       const instance = createServiceInstanceByStep('programSelect', 'channel');
       expect(instance.isCompletedOrCurrentStep('providerTypeSelect')).toBe(true);
-      expect(instance.isCompletedOrCurrentStep('broadcastChannelSelect')).toBe(true);
+      expect(instance.isCompletedOrCurrentStep('channelSelect')).toBe(true);
       expect(instance.isCompletedOrCurrentStep('programSelect')).toBe(true);
       expect(instance.isCompletedOrCurrentStep('confirm')).toBe(false);
     });
     test('confirm ステップ (チャンネル番組) のインスタンスに対して正しい値を返す', () => {
       const instance = createServiceInstanceByStep('confirm', 'channel');
       expect(instance.isCompletedOrCurrentStep('providerTypeSelect')).toBe(true);
-      expect(instance.isCompletedOrCurrentStep('broadcastChannelSelect')).toBe(true);
+      expect(instance.isCompletedOrCurrentStep('channelSelect')).toBe(true);
       expect(instance.isCompletedOrCurrentStep('programSelect')).toBe(true);
       expect(instance.isCompletedOrCurrentStep('confirm')).toBe(true);
     });
     test('confirm ステップ (ユーザー番組) のインスタンスに対して正しい値を返す', () => {
       const instance = createServiceInstanceByStep('confirm', 'user');
       expect(instance.isCompletedOrCurrentStep('providerTypeSelect')).toBe(true);
-      expect(instance.isCompletedOrCurrentStep('broadcastChannelSelect')).toBe(false); // ユーザー番組は経由しない
+      expect(instance.isCompletedOrCurrentStep('channelSelect')).toBe(false); // ユーザー番組は経由しない
       expect(instance.isCompletedOrCurrentStep('programSelect')).toBe(false); // ユーザー番組は経由しない
     });
   });
@@ -292,35 +292,35 @@ describe('ステップ比較系メソッド', () => {
       // 初期状態なので, 'user' でも同様.
       const instance = createServiceInstanceByStep('providerTypeSelect', 'channel');
       expect(instance.isCompletedStep('providerTypeSelect')).toBe(false);
-      expect(instance.isCompletedStep('broadcastChannelSelect')).toBe(false);
+      expect(instance.isCompletedStep('channelSelect')).toBe(false);
       expect(instance.isCompletedStep('programSelect')).toBe(false);
       expect(instance.isCompletedStep('confirm')).toBe(false);
     });
-    test('broadcastChannelSelect ステップのインスタンスに対して正しい値を返す', () => {
-      const instance = createServiceInstanceByStep('broadcastChannelSelect', 'channel');
+    test('channelSelect ステップのインスタンスに対して正しい値を返す', () => {
+      const instance = createServiceInstanceByStep('channelSelect', 'channel');
       expect(instance.isCompletedStep('providerTypeSelect')).toBe(true);
-      expect(instance.isCompletedStep('broadcastChannelSelect')).toBe(false);
+      expect(instance.isCompletedStep('channelSelect')).toBe(false);
       expect(instance.isCompletedStep('programSelect')).toBe(false);
       expect(instance.isCompletedStep('confirm')).toBe(false);
     });
     test('programSelect ステップのインスタンスに対して正しい値を返す', () => {
       const instance = createServiceInstanceByStep('programSelect', 'channel');
       expect(instance.isCompletedStep('providerTypeSelect')).toBe(true);
-      expect(instance.isCompletedStep('broadcastChannelSelect')).toBe(true);
+      expect(instance.isCompletedStep('channelSelect')).toBe(true);
       expect(instance.isCompletedStep('programSelect')).toBe(false);
       expect(instance.isCompletedStep('confirm')).toBe(false);
     });
     test('confirm ステップ (チャンネル番組) のインスタンスに対して正しい値を返す', () => {
       const instance = createServiceInstanceByStep('confirm', 'channel');
       expect(instance.isCompletedStep('providerTypeSelect')).toBe(true);
-      expect(instance.isCompletedStep('broadcastChannelSelect')).toBe(true);
+      expect(instance.isCompletedStep('channelSelect')).toBe(true);
       expect(instance.isCompletedStep('programSelect')).toBe(true);
       expect(instance.isCompletedStep('confirm')).toBe(false);
     });
     test('confirm ステップ (ユーザー番組) のインスタンスに対して正しい値を返す', () => {
       const instance = createServiceInstanceByStep('confirm', 'user');
       expect(instance.isCompletedStep('providerTypeSelect')).toBe(true);
-      expect(instance.isCompletedStep('broadcastChannelSelect')).toBe(false); // ユーザー番組は経由しない
+      expect(instance.isCompletedStep('channelSelect')).toBe(false); // ユーザー番組は経由しない
       expect(instance.isCompletedStep('programSelect')).toBe(false); // ユーザー番組は経由しない
       expect(instance.isCompletedStep('confirm')).toBe(false);
     });
@@ -331,7 +331,7 @@ describe('ステップ比較系メソッド', () => {
         const instance = createServiceInstanceByStep('providerTypeSelect', 'channel');
         (instance as any).SET_STATE = jest.fn();
         instance.backTo('providerTypeSelect');
-        instance.backTo('broadcastChannelSelect');
+        instance.backTo('channelSelect');
         instance.backTo('programSelect');
         instance.backTo('confirm');
         expect((instance as any).SET_STATE).not.toBeCalled();
@@ -339,7 +339,7 @@ describe('ステップ比較系メソッド', () => {
     });
     describe('broadcastChanelSelect ステップのインスタンスに対して状態をクリアできる', () => {
       test('providerTypeSelect ステップに戻るときに適切な状態に初期化できる', () => {
-        const instance = createServiceInstanceByStep('broadcastChannelSelect', 'channel');
+        const instance = createServiceInstanceByStep('channelSelect', 'channel');
         instance.backTo('providerTypeSelect');
         expect(instance.state).toMatchObject({
           currentStep: 'providerTypeSelect',
@@ -350,9 +350,9 @@ describe('ステップ比較系メソッド', () => {
         });
       });
       test('その他のステップに戻ろうとしても何も起こらない', () => {
-        const instance = createServiceInstanceByStep('broadcastChannelSelect', 'channel');
+        const instance = createServiceInstanceByStep('channelSelect', 'channel');
         (instance as any).SET_STATE = jest.fn();
-        instance.backTo('broadcastChannelSelect');
+        instance.backTo('channelSelect');
         instance.backTo('programSelect');
         instance.backTo('confirm');
         expect((instance as any).SET_STATE).not.toBeCalled();
@@ -370,11 +370,11 @@ describe('ステップ比較系メソッド', () => {
           selectedProgram: null
         });
       });
-      test('broadcastChannelSelect ステップに戻るときに適切な状態に初期化できる', () => {
+      test('channelSelect ステップに戻るときに適切な状態に初期化できる', () => {
         const instance = createServiceInstanceByStep('programSelect', 'channel');
-        instance.backTo('broadcastChannelSelect');
+        instance.backTo('channelSelect');
         expect(instance.state).toMatchObject({
-          currentStep: 'broadcastChannelSelect',
+          currentStep: 'channelSelect',
           candidatePrograms: [],
           selectedProviderType: 'channel',
           selectedChannel: null,
@@ -401,11 +401,11 @@ describe('ステップ比較系メソッド', () => {
           selectedProgram: null
         });
       });
-      test('broadcastChannelSelect ステップに戻るときに適切な状態に初期化できる', () => {
+      test('channelSelect ステップに戻るときに適切な状態に初期化できる', () => {
         const instance = createServiceInstanceByStep('confirm', 'channel');
-        instance.backTo('broadcastChannelSelect');
+        instance.backTo('channelSelect');
         expect(instance.state).toMatchObject({
-          currentStep: 'broadcastChannelSelect',
+          currentStep: 'channelSelect',
           candidatePrograms: [],
           selectedProviderType: 'channel',
           selectedChannel: null,
@@ -450,7 +450,7 @@ describe('ステップ比較系メソッド', () => {
       test('他のステップに戻ろうとしても何も起こらない', () => {
         const instance = createServiceInstanceByStep('confirm', 'user');
         (instance as any).SET_STATE = jest.fn();
-        instance.backTo('broadcastChannelSelect'); // ユーザー番組ではスキップされるため無効
+        instance.backTo('channelSelect'); // ユーザー番組ではスキップされるため無効
         instance.backTo('programSelect');  // ユーザー番組ではスキップされるため無効
         instance.backTo('confirm');
         expect((instance as any).SET_STATE).not.toBeCalled();

--- a/app/services/nicolive-program/nicolive-program-selector.test.ts
+++ b/app/services/nicolive-program/nicolive-program-selector.test.ts
@@ -27,7 +27,7 @@ test('ユーザー番組を選んで配信開始のための番組情報を準�
 
   // 確認へ
   const programId = 'lv1111';
-  instance.onSelectUserProgram(programId);
+  instance.onSelectProviderTypeUser(programId);
   expect(instance.state.currentStep).toBe('confirm');
   expect(instance.state.selectedProviderType).toBe('user');
   expect(instance.state.selectedChannel).toBeNull();
@@ -41,7 +41,7 @@ test('チャンネル番組を選んで配信開始のための番組情報を�
   expect(instance.state.currentStep).toBe('providerTypeSelect');
 
   // チャンネル選択へ
-  instance.onSelectChannelProgram();
+  instance.onSelectProviderTypeChannel();
   expect(instance.state.currentStep).toBe('broadcastChannelSelect');
   expect(instance.state.selectedProviderType).toBe('channel');
 
@@ -91,17 +91,17 @@ test('チャンネル選択ステップで, 配信種別や番組の選択をし
   expect(instance.state.currentStep).toBe('providerTypeSelect');
 
   // チャンネル選択へ
-  instance.onSelectChannelProgram();
+  instance.onSelectProviderTypeChannel();
   expect(instance.state.currentStep).toBe('broadcastChannelSelect');
   expect(instance.state.selectedProviderType).toBe('channel');
 
   // 配信種別をチャンネルに変更しようとしても何も起きない
-  instance.onSelectChannelProgram();
+  instance.onSelectProviderTypeChannel();
   expect(instance.state.currentStep).toBe('broadcastChannelSelect');
   expect(instance.state.selectedProviderType).toBe('channel');
 
   // 配信種別をユーザー番組に変更できない
-  instance.onSelectUserProgram('lv1');
+  instance.onSelectProviderTypeUser('lv1');
   expect(instance.state.currentStep).toBe('broadcastChannelSelect');
   expect(instance.state.selectedProviderType).toBe('channel');
 
@@ -118,7 +118,7 @@ test('番組選択ステップで, 配信種別やチャンネルの選択をし
   expect(instance.state.currentStep).toBe('providerTypeSelect');
 
   // チャンネル選択へ
-  instance.onSelectChannelProgram();
+  instance.onSelectProviderTypeChannel();
 
   // 番組選択へ
   const selectedChannelId = 'ch9999';
@@ -126,12 +126,12 @@ test('番組選択ステップで, 配信種別やチャンネルの選択をし
   expect(instance.state.currentStep).toBe('programSelect');
 
   // 配信種別をチャンネルに変更しようとしても何も起きない
-  instance.onSelectChannelProgram();
+  instance.onSelectProviderTypeChannel();
   expect(instance.state.currentStep).toBe('programSelect');
   expect(instance.state.selectedProviderType).toBe('channel');
 
   // 配信種別をユーザー番組に変更できない
-  instance.onSelectUserProgram('lv1');
+  instance.onSelectProviderTypeUser('lv1');
   expect(instance.state.currentStep).toBe('programSelect');
   expect(instance.state.selectedProviderType).toBe('channel');
 
@@ -148,16 +148,16 @@ test('ユーザー番組の確認ステップでは, あらゆる設定済の項
   expect(instance.state.currentStep).toBe('providerTypeSelect');
 
   // 確認へ
-  instance.onSelectUserProgram('lv9800');
+  instance.onSelectProviderTypeUser('lv9800');
   expect(instance.state.currentStep).toBe('confirm');
 
   // 配信種別をチャンネルに変更できない
-  instance.onSelectChannelProgram();
+  instance.onSelectProviderTypeChannel();
   expect(instance.state.currentStep).toBe('confirm');
   expect(instance.state.selectedProviderType).toBe('user');
 
   // 配信種別をユーザーに変更しようとしても何も起きない
-  instance.onSelectChannelProgram();
+  instance.onSelectProviderTypeChannel();
   expect(instance.state.currentStep).toBe('confirm');
   expect(instance.state.selectedProviderType).toBe('user');
 
@@ -180,7 +180,7 @@ test('チャンネル番組の確認ステップでは, あらゆる設定済の
   const instance = NicoliveProgramSelectorService.instance as NicoliveProgramSelectorService;
   expect(instance.state.currentStep).toBe('providerTypeSelect');
   // チャンネル選択へ
-  instance.onSelectChannelProgram();
+  instance.onSelectProviderTypeChannel();
 
   // 番組選択へ
   const selectedChannelId = 'ch9999';
@@ -192,12 +192,12 @@ test('チャンネル番組の確認ステップでは, あらゆる設定済の
   expect(instance.state.currentStep).toBe('confirm');
 
   // 配信種別をチャンネルに変更しようとしても何も起きない
-  instance.onSelectChannelProgram();
+  instance.onSelectProviderTypeChannel();
   expect(instance.state.currentStep).toBe('confirm');
   expect(instance.state.selectedProviderType).toBe('channel');
 
   // 配信種別をユーザーに変更できない
-  instance.onSelectChannelProgram();
+  instance.onSelectProviderTypeChannel();
   expect(instance.state.currentStep).toBe('confirm');
   expect(instance.state.selectedProviderType).toBe('channel');
 
@@ -226,7 +226,7 @@ describe('ステップ比較系メソッド', () => {
         case 'providerTypeSelect':
           return instance;
         case 'confirm':
-          instance.onSelectUserProgram('id');
+          instance.onSelectProviderTypeUser('id');
           return instance;
         default:
           throw new Error('作れません')
@@ -236,14 +236,14 @@ describe('ステップ比較系メソッド', () => {
         case 'providerTypeSelect':
           return instance;
         case 'broadcastChannelSelect':
-          instance.onSelectChannelProgram();
+          instance.onSelectProviderTypeChannel();
           return instance;
         case 'programSelect':
-          instance.onSelectChannelProgram();
+          instance.onSelectProviderTypeChannel();
           instance.onSelectChannel('ch9999', 'name', ['lv1', 'lv2', 'lv3']);
           return instance;
         case 'confirm':
-          instance.onSelectChannelProgram();
+          instance.onSelectProviderTypeChannel();
           instance.onSelectChannel('ch9999', 'name', ['lv1', 'lv2', 'lv3']);
           instance.onSelectBroadcastingProgram('id', 'title');
           return instance;

--- a/app/services/nicolive-program/nicolive-program-selector.ts
+++ b/app/services/nicolive-program/nicolive-program-selector.ts
@@ -87,9 +87,9 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
    * 番組選択ステップへ移動後, APIを叩いて番組IDからタイトルを解決し, candidatePrograms に番組IDとタイトルを保存する.
    * @param id 配信するチャンネルID (chXXXX)
    * @param name 配信するチャンネル名
-   * @param broadcastableProgramIds 配信可能な番組ID (lvXXXX) の一覧
+   * @param broadcastablePrograms 配信可能な番組 の一覧
    */
-  onSelectChannel(id: string, name: string, broadcastableProgramIds: string[]) {
+  onSelectChannel(id: string, name: string, broadcastablePrograms: { id: string }[]) {
     if(this.state.currentStep !== 'channelSelect') {
       return;
     }
@@ -100,9 +100,9 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
       isLoading: true
     });
     // TODO: API から番組タイトルを取得するようにする. 現在は仮のタイトルを指定.
-    const candidatePrograms = broadcastableProgramIds.map(programId => ({
-      id: programId,
-      title: `これは ${programId} のタイトルです`
+    const candidatePrograms = broadcastablePrograms.map(program => ({
+      id: program.id,
+      title: `これは ${program.id} のタイトルです`
     }));
     // ↑ ここまで仮の処理
     this.SET_STATE({

--- a/app/services/nicolive-program/nicolive-program-selector.ts
+++ b/app/services/nicolive-program/nicolive-program-selector.ts
@@ -1,0 +1,181 @@
+import { StatefulService, mutation } from 'services/stateful-service';
+
+/**
+ * 配信する番組種別
+ * 配列の並び順は表示順序.
+ */
+export const providerTypes = ['channel', 'user'] as const;
+export type TProviderType = typeof providerTypes[number];
+
+/**
+ * 選択肢からなるステップ.
+ * 配列の並び順はステップの順序.
+ */
+export const selectionSteps = ['providerTypeSelect', 'broadcastChannelSelect', 'programSelect'] as const;
+export type TSelectionStep = typeof selectionSteps[number];
+
+/**
+ * 最後の「確認」を含めた全ステップ.
+ * 配列の並び順はステップの順序.
+ */
+export const steps = [...selectionSteps, 'confirm'] as const;
+export type TStep = typeof steps[number];
+
+/**
+ * ステップ名をキーに, その順番(0, 1...)を値にしたオブジェクト.
+ * ステップ同士の順序の判定に使用する.
+ * ```
+ * {
+ *   'providerTypeSelect': 0
+ *   'broadcastChannelSelect': 1, 
+ *   // ...
+ * }
+ * ```
+ */
+const stepsMap = steps.reduce<{ [key in TStep]?: number }>((prev, current, index) => (
+  { ...prev, [current]: index }), {}
+) as { [key in TStep]: number };
+
+export interface INicoliveProgramSelectorState {
+  selectedProviderType: TProviderType | null;
+  selectedChannel: { id: string; name: string } | null;
+  selectedProgram: { id: string; title?: string } | null; // ユーザー番組の場合はタイトルは取得せず undefined のまま
+  candidatePrograms: { id: string; title: string }[];
+  isLoading: boolean;
+  currentStep: TStep;
+}
+
+export class NicoliveProgramSelectorService extends StatefulService<INicoliveProgramSelectorState> {
+
+  static initialState: INicoliveProgramSelectorState = {
+    selectedProviderType: null,
+    selectedChannel: null,
+    selectedProgram:  null,
+    candidatePrograms: [],
+    isLoading: false,
+    currentStep: 'providerTypeSelect'
+  };
+
+  init() {
+    super.init();
+  }
+
+  onSelectChannelProgram() {
+    if (this.state.currentStep !== 'providerTypeSelect') {
+      return;
+    }
+    this.SET_STATE({
+      selectedProviderType: 'channel',
+      currentStep: 'broadcastChannelSelect'
+    });
+  }
+
+  onSelectUserProgram(userProgramId: string) {
+    if (this.state.currentStep !== 'providerTypeSelect') {
+      return;
+    }
+    this.SET_STATE({
+      selectedProviderType: 'user',
+      selectedChannel: null,
+      selectedProgram: { id: userProgramId },
+      currentStep: 'confirm'
+    });
+  }
+
+  /**
+   * 配信先チャンネルを選択したときの処理.
+   * 番組選択ステップへ移動後, APIを叩いて番組IDからタイトルを解決し, candidatePrograms に番組IDとタイトルを保存する.
+   * @param id 配信するチャンネルID (chXXXX)
+   * @param name 配信するチャンネル名
+   * @param broadcastableProgramIds 配信可能な番組ID (lvXXXX) の一覧
+   */
+  onSelectChannel(id: string, name: string, broadcastableProgramIds: string[]) {
+    if(this.state.currentStep !== 'broadcastChannelSelect') {
+      return;
+    }
+    this.SET_STATE({
+      selectedChannel: { id, name },
+      currentStep: 'programSelect',
+      candidatePrograms: [],
+      isLoading: true
+    });
+    // TODO: API から番組タイトルを取得するようにする. 現在は仮のタイトルを指定.
+    const candidatePrograms = broadcastableProgramIds.map(programId => ({
+      id: programId,
+      title: `これは ${programId} のタイトルです`
+    }));
+    // ↑ ここまで仮の処理
+    this.SET_STATE({
+      candidatePrograms,
+      isLoading: false
+    });
+  }
+
+  onSelectBroadcastingProgram(id: string, title: string) {
+    if(this.state.currentStep !== 'programSelect') {
+      return;
+    }
+    this.SET_STATE({
+      selectedProgram: { id, title },
+      currentStep: 'confirm'
+    });
+  }
+
+  /**
+   * 与えられたステップが現在のステップもしくはすでに完了したステップであるか.
+   * @param step
+   */
+  isCompletedOrCurrentStep(step: TStep): boolean {
+    if (this.isStepToSkip(step, this.state.selectedProviderType)) {
+      return false;
+    }
+    return stepsMap[this.state.currentStep] >= stepsMap[step];
+  }
+
+  /**
+   * 与えられたステップがすでに完了したステップであるか.
+   * @param step 
+   */
+  isCompletedStep(step: TStep): boolean {
+    if (this.isStepToSkip(step, this.state.selectedProviderType)) {
+      return false;
+    }
+    return stepsMap[this.state.currentStep] > stepsMap[step];
+  }
+
+  /**
+   * 指定ステップに戻る.
+   * 指定ステップ以降で設定された値は初期値にリセットする.
+   * @param step 
+   */
+  backTo(step: TStep) {
+    this.SET_STATE({
+      currentStep: step,
+      candidatePrograms: stepsMap[step] <= stepsMap['broadcastChannelSelect'] ? [] : this.state.candidatePrograms,
+      selectedProviderType:  stepsMap[step] <= stepsMap['providerTypeSelect'] ? null :this.state.selectedProviderType,
+      selectedChannel:   stepsMap[step] <= stepsMap['broadcastChannelSelect'] ? null : this.state.selectedChannel,
+      selectedProgram: stepsMap[step] <= stepsMap['programSelect']  ? null : this.state.selectedProgram,
+    });
+  }
+
+  /**
+   * ユーザー生放送が選択されている場合,
+   * 与えられたステップがスキップされるべきものなら true を, さもなくば false を返す.
+   * チャンネル生放送が選択されている場合, 常に false を返す.
+   * @param step 
+   * @param providerType 
+   */
+  private isStepToSkip(step: TStep, providerType: TProviderType): boolean {
+    return (
+      providerType === 'user' && (
+        step === 'programSelect' || step === 'broadcastChannelSelect'
+      )
+    );
+  }
+
+  @mutation()
+  private SET_STATE(nextState: Partial<INicoliveProgramSelectorState>) {
+    this.state = { ...this.state, ...nextState };
+    console.log(this.state);
+  }
+}

--- a/app/services/nicolive-program/nicolive-program-selector.ts
+++ b/app/services/nicolive-program/nicolive-program-selector.ts
@@ -146,14 +146,18 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
   /**
    * 指定ステップに戻る.
    * 指定ステップ以降で設定された値は初期値にリセットする.
+   * 完了していないステップが与えられた場合は何もしない.
    * @param step 
    */
   backTo(step: TStep) {
+    if (!this.isCompletedStep(step)) {
+      return;
+    }
     this.SET_STATE({
       currentStep: step,
       candidatePrograms: stepsMap[step] <= stepsMap['broadcastChannelSelect'] ? [] : this.state.candidatePrograms,
-      selectedProviderType:  stepsMap[step] <= stepsMap['providerTypeSelect'] ? null :this.state.selectedProviderType,
-      selectedChannel:   stepsMap[step] <= stepsMap['broadcastChannelSelect'] ? null : this.state.selectedChannel,
+      selectedProviderType: stepsMap[step] <= stepsMap['providerTypeSelect'] ? null : this.state.selectedProviderType,
+      selectedChannel: stepsMap[step] <= stepsMap['broadcastChannelSelect'] ? null : this.state.selectedChannel,
       selectedProgram: stepsMap[step] <= stepsMap['programSelect']  ? null : this.state.selectedProgram,
     });
   }
@@ -176,6 +180,5 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
   @mutation()
   private SET_STATE(nextState: Partial<INicoliveProgramSelectorState>) {
     this.state = { ...this.state, ...nextState };
-    console.log(this.state);
   }
 }

--- a/app/services/nicolive-program/nicolive-program-selector.ts
+++ b/app/services/nicolive-program/nicolive-program-selector.ts
@@ -60,7 +60,7 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
     super.init();
   }
 
-  onSelectChannelProgram() {
+  onSelectProviderTypeChannel() {
     if (this.state.currentStep !== 'providerTypeSelect') {
       return;
     }
@@ -70,7 +70,7 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
     });
   }
 
-  onSelectUserProgram(userProgramId: string) {
+  onSelectProviderTypeUser(userProgramId: string) {
     if (this.state.currentStep !== 'providerTypeSelect') {
       return;
     }

--- a/app/services/nicolive-program/nicolive-program-selector.ts
+++ b/app/services/nicolive-program/nicolive-program-selector.ts
@@ -11,7 +11,7 @@ export type TProviderType = typeof providerTypes[number];
  * 選択肢からなるステップ.
  * 配列の並び順はステップの順序.
  */
-export const selectionSteps = ['providerTypeSelect', 'broadcastChannelSelect', 'programSelect'] as const;
+export const selectionSteps = ['providerTypeSelect', 'channelSelect', 'programSelect'] as const;
 export type TSelectionStep = typeof selectionSteps[number];
 
 /**
@@ -27,7 +27,7 @@ export type TStep = typeof steps[number];
  * ```
  * {
  *   'providerTypeSelect': 0
- *   'broadcastChannelSelect': 1, 
+ *   'channelSelect': 1, 
  *   // ...
  * }
  * ```
@@ -66,7 +66,7 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
     }
     this.SET_STATE({
       selectedProviderType: 'channel',
-      currentStep: 'broadcastChannelSelect'
+      currentStep: 'channelSelect'
     });
   }
 
@@ -90,7 +90,7 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
    * @param broadcastableProgramIds 配信可能な番組ID (lvXXXX) の一覧
    */
   onSelectChannel(id: string, name: string, broadcastableProgramIds: string[]) {
-    if(this.state.currentStep !== 'broadcastChannelSelect') {
+    if(this.state.currentStep !== 'channelSelect') {
       return;
     }
     this.SET_STATE({
@@ -155,9 +155,9 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
     }
     this.SET_STATE({
       currentStep: step,
-      candidatePrograms: stepsMap[step] <= stepsMap['broadcastChannelSelect'] ? [] : this.state.candidatePrograms,
+      candidatePrograms: stepsMap[step] <= stepsMap['channelSelect'] ? [] : this.state.candidatePrograms,
       selectedProviderType: stepsMap[step] <= stepsMap['providerTypeSelect'] ? null : this.state.selectedProviderType,
-      selectedChannel: stepsMap[step] <= stepsMap['broadcastChannelSelect'] ? null : this.state.selectedChannel,
+      selectedChannel: stepsMap[step] <= stepsMap['channelSelect'] ? null : this.state.selectedChannel,
       selectedProgram: stepsMap[step] <= stepsMap['programSelect']  ? null : this.state.selectedProgram,
     });
   }
@@ -172,7 +172,7 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
   private isStepToSkip(step: TStep, providerType: TProviderType): boolean {
     return (
       providerType === 'user' && (
-        step === 'programSelect' || step === 'broadcastChannelSelect'
+        step === 'programSelect' || step === 'channelSelect'
       )
     );
   }

--- a/app/services/platforms/__snapshots__/niconico.test.ts.snap
+++ b/app/services/platforms/__snapshots__/niconico.test.ts.snap
@@ -30,8 +30,8 @@ Array [
   Object {
     "componentName": "NicoliveProgramSelector",
     "queryParams": Object {
-      "channels": Object {
-        "ch1": Object {
+      "channels": Array [
+        Object {
           "broadcastablePrograms": Array [
             Object {
               "id": "lv1111111111",
@@ -40,11 +40,12 @@ Array [
               "id": "lv2222222222",
             },
           ],
+          "id": "ch1",
           "name": "テスト用チャンネル1",
           "thumbnailUrl": "https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg",
           "type": "channel",
         },
-        "ch2": Object {
+        Object {
           "broadcastablePrograms": Array [
             Object {
               "id": "lv4444444444",
@@ -53,25 +54,25 @@ Array [
               "id": "lv5555555555",
             },
           ],
+          "id": "ch2",
           "name": "テスト用チャンネル2",
           "thumbnailUrl": "https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg",
           "type": "channel",
         },
-      },
-      "communities": Object {
-        "co1": Object {
-          "broadcastablePrograms": Array [
-            Object {
-              "id": "lv1",
-            },
-            Object {
-              "id": "lv2",
-            },
-          ],
-          "name": "テスト用コミュニティ",
-          "thumbnailUrl": "https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg",
-          "type": "community",
-        },
+      ],
+      "community": Object {
+        "broadcastablePrograms": Array [
+          Object {
+            "id": "lv1",
+          },
+          Object {
+            "id": "lv2",
+          },
+        ],
+        "id": "co1",
+        "name": "テスト用コミュニティ",
+        "thumbnailUrl": "https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg",
+        "type": "community",
       },
     },
     "size": Object {

--- a/app/services/platforms/__snapshots__/niconico.test.ts.snap
+++ b/app/services/platforms/__snapshots__/niconico.test.ts.snap
@@ -32,24 +32,46 @@ Array [
     "queryParams": Object {
       "channels": Object {
         "ch1": Object {
-          "broadcastableProgramIds": Array [
-            "lv1111111111",
-            "lv2222222222",
+          "broadcastablePrograms": Array [
+            Object {
+              "id": "lv1111111111",
+            },
+            Object {
+              "id": "lv2222222222",
+            },
           ],
           "name": "テスト用チャンネル1",
           "thumbnailUrl": "https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg",
+          "type": "channel",
         },
         "ch2": Object {
-          "broadcastableProgramIds": Array [
-            "lv4444444444",
-            "lv5555555555",
+          "broadcastablePrograms": Array [
+            Object {
+              "id": "lv4444444444",
+            },
+            Object {
+              "id": "lv5555555555",
+            },
           ],
           "name": "テスト用チャンネル2",
           "thumbnailUrl": "https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg",
+          "type": "channel",
         },
       },
-      "user": Object {
-        "broadcastableProgramId": "lv10",
+      "communities": Object {
+        "co1": Object {
+          "broadcastablePrograms": Array [
+            Object {
+              "id": "lv1",
+            },
+            Object {
+              "id": "lv2",
+            },
+          ],
+          "name": "テスト用コミュニティ",
+          "thumbnailUrl": "https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg",
+          "type": "community",
+        },
       },
     },
     "size": Object {

--- a/app/services/platforms/__snapshots__/niconico.test.ts.snap
+++ b/app/services/platforms/__snapshots__/niconico.test.ts.snap
@@ -30,20 +30,31 @@ Array [
   Object {
     "componentName": "NicoliveProgramSelector",
     "queryParams": Object {
-      "channelId1": Object {
-        "bitrate": "bitrate1",
-        "key": "key1",
-        "url": "url1",
+      "channels": Object {
+        "co1": Object {
+          "broadcastableProgramIds": Array [
+            "lv1111111111",
+            "lv2222222222",
+          ],
+          "name": "テスト用コミュニティ1",
+          "thumbnailUrl": "https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg",
+        },
+        "co2": Object {
+          "broadcastableProgramIds": Array [
+            "lv4444444444",
+            "lv5555555555",
+          ],
+          "name": "テスト用コミュニティ2",
+          "thumbnailUrl": "https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg",
+        },
       },
-      "channelId2": Object {
-        "bitrate": "bitrate2",
-        "key": "key2",
-        "url": "url2",
+      "user": Object {
+        "broadcastableProgramId": "lv10",
       },
     },
     "size": Object {
-      "height": 400,
-      "width": 700,
+      "height": 800,
+      "width": 800,
     },
   },
 ]

--- a/app/services/platforms/__snapshots__/niconico.test.ts.snap
+++ b/app/services/platforms/__snapshots__/niconico.test.ts.snap
@@ -31,20 +31,20 @@ Array [
     "componentName": "NicoliveProgramSelector",
     "queryParams": Object {
       "channels": Object {
-        "co1": Object {
+        "ch1": Object {
           "broadcastableProgramIds": Array [
             "lv1111111111",
             "lv2222222222",
           ],
-          "name": "テスト用コミュニティ1",
+          "name": "テスト用チャンネル1",
           "thumbnailUrl": "https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg",
         },
-        "co2": Object {
+        "ch2": Object {
           "broadcastableProgramIds": Array [
             "lv4444444444",
             "lv5555555555",
           ],
-          "name": "テスト用コミュニティ2",
+          "name": "テスト用チャンネル2",
           "thumbnailUrl": "https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg",
         },
       },

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -74,14 +74,15 @@ type Program = {
 
 type SocialGroup = {
   type: 'community' | 'channel';
+  id: string;
   name: string;
   thumbnailUrl: string;
   broadcastablePrograms: Program[];
 }
 
 export type LiveProgramInfo2 = {
-  communities: Dictionary<SocialGroup>;
-  channels: Dictionary<SocialGroup>;
+  community: SocialGroup;
+  channels: SocialGroup[];
 }
 
 class GetPublishStatusResult {
@@ -275,28 +276,29 @@ export class NiconicoService extends Service implements IPlatformService {
         componentName: 'NicoliveProgramSelector',
         // TODO: APIから取得した放送可能な番組を埋めて queryParams に渡す.
         queryParams: {
-          communities: {
-            'co1': {
+          community: {
+              id: 'co1',
               type: 'community',
               name: 'テスト用コミュニティ',
               thumbnailUrl: 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
               broadcastablePrograms: [{ id: 'lv1' }, { id: 'lv2' }]
-            },
           },
-          channels: {
-            'ch1': {
+          channels: [
+             {
+              id: 'ch1',
               type: 'channel',
               thumbnailUrl: 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
               name: 'テスト用チャンネル1',
               broadcastablePrograms: [{ id: 'lv1111111111' }, { id: 'lv2222222222' }]
             },
-            'ch2': {
+            {
+              id: 'ch2',
               type: 'channel',
               thumbnailUrl: 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
               name: 'テスト用チャンネル2',
               broadcastablePrograms: [{ id: 'lv4444444444' }, { id: 'lv5555555555' }]
             }
-          }
+          ]
         } as LiveProgramInfo2,
         // 仮のコードここまで ↑
         size: {

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -68,17 +68,21 @@ export type LiveProgramInfo = Dictionary<{
   key: string
 }>
 
-// TODO: 旧 LiveProgramInfo が消えたら 名前を LiveProgramInfo にする
-export type LiveProgramInfo2 = {
-  user: {
-    broadcastableProgramId: string;
-  },
-  channels: Dictionary<{
-    thumbnailUrl: string;
-    name: string;
-    broadcastableProgramIds: string[];
-  }>;
+type Program = {
+  id: string;
 };
+
+type SocialGroup = {
+  type: 'community' | 'channel';
+  name: string;
+  thumbnailUrl: string;
+  broadcastablePrograms: Program[];
+}
+
+export type LiveProgramInfo2 = {
+  communities: Dictionary<SocialGroup>;
+  channels: Dictionary<SocialGroup>;
+}
 
 class GetPublishStatusResult {
   attrib: object;
@@ -271,22 +275,29 @@ export class NiconicoService extends Service implements IPlatformService {
         componentName: 'NicoliveProgramSelector',
         // TODO: APIから取得した放送可能な番組を埋めて queryParams に渡す.
         queryParams: {
-          user: {
-            broadcastableProgramId: 'lv10'
+          communities: {
+            'co1': {
+              type: 'community',
+              name: 'テスト用コミュニティ',
+              thumbnailUrl: 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
+              broadcastablePrograms: [{ id: 'lv1' }, { id: 'lv2' }]
+            },
           },
           channels: {
             'ch1': {
+              type: 'channel',
               thumbnailUrl: 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
               name: 'テスト用チャンネル1',
-              broadcastableProgramIds: ['lv1111111111', 'lv2222222222']
+              broadcastablePrograms: [{ id: 'lv1111111111' }, { id: 'lv2222222222' }]
             },
             'ch2': {
+              type: 'channel',
               thumbnailUrl: 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
               name: 'テスト用チャンネル2',
-              broadcastableProgramIds: ['lv4444444444', 'lv5555555555']
+              broadcastablePrograms: [{ id: 'lv4444444444' }, { id: 'lv5555555555' }]
             }
           }
-        },
+        } as LiveProgramInfo2,
         // 仮のコードここまで ↑
         size: {
           width: 800,

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -275,14 +275,14 @@ export class NiconicoService extends Service implements IPlatformService {
             broadcastableProgramId: 'lv10'
           },
           channels: {
-            'co1': {
+            'ch1': {
               thumbnailUrl: 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
-              name: 'テスト用コミュニティ1',
+              name: 'テスト用チャンネル1',
               broadcastableProgramIds: ['lv1111111111', 'lv2222222222']
             },
-            'co2': {
+            'ch2': {
               thumbnailUrl: 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
-              name: 'テスト用コミュニティ2',
+              name: 'テスト用チャンネル2',
               broadcastableProgramIds: ['lv4444444444', 'lv5555555555']
             }
           }


### PR DESCRIPTION
# このpull requestが解決する内容
新しい番組選択ダイアログを実装します。スタイルは最低限それっぽいものを当てています。

## 特に見てほしい点
- `NavItem`, `NavMenu` コンポーネントの流用が適切か
- ステップの状態管理の方法
- サービスの書き方

## このPRの時点ではやっていないこと
- 配信可能な番組を取得すること（ダミーのテストデータを表示させるようになっています)
- ダイアログを出す判定条件 (チャンネルを持っていなくても必ずダイアログが出るようになっています)
- 放送可能な番組が0件の場合の処理 (実際の放送可能番組が取れるまで実装できない)
- niconico.ts のテストが壊れている件 (@taroc さんと調整中)
- e2eテスト
- 辞書の英訳 (新規に追加した項目は空文字列になっています)

# 動作確認手順
## UI
1. `yarn install`
2. `yarn compile`
3. `yarn start`
4. niconicoにログインされていなければログインする
5. 配信開始を押す
![dialog](https://user-images.githubusercontent.com/905919/92853953-65fbe700-f42b-11ea-814e-721cd3f12391.gif)

## テスト
- `yarn test:unit` で、 `niconico.ts` の3箇所(本PRの範疇を超えるため別PRでの修正を調整中) 以外失敗しないこと

# 関連するIssue（あれば）
https://github.com/n-air-app/n-air-app/issues/442

デザイン資料: https://atl.dwango.co.jp/confluence/pages/viewpage.action?pageId=199320319 (社内)
