### PR TITLE
feat(api): getpublishstatu APIを新しいAPIに乗り換えた

### DIFF
--- a/app/components/windows/NicoliveProgramSelector.vue.ts
+++ b/app/components/windows/NicoliveProgramSelector.vue.ts
@@ -16,7 +16,7 @@ import {
   selectionSteps as _selectionSteps,
   TSelectionStep
 } from 'services/nicolive-program/nicolive-program-selector';
-import { LiveProgramInfo2 } from 'services/platforms/niconico';
+import { LiveProgramInfo } from 'services/platforms/niconico';
 import { StreamingService } from 'services/streaming';
 import { $t } from 'services/i18n';
 
@@ -34,7 +34,7 @@ export default class NicoliveProgramSelector extends Vue {
   @Inject() windowsService: WindowsService;
   @Inject() streamingService: StreamingService;
 
-  queryParams = this.windowsService.getChildWindowOptions().queryParams as LiveProgramInfo2;
+  queryParams = this.windowsService.getChildWindowOptions().queryParams as LiveProgramInfo;
 
   readonly providerTypes = _providerTypes;
   readonly steps = _steps;

--- a/app/services/hosts.ts
+++ b/app/services/hosts.ts
@@ -18,9 +18,6 @@ export class HostsService extends Service {
   get niconicolive() {
     return 'http://live.nicovideo.jp';
   }
-  get niconicoRelive() {
-    return 'http://live2.nicovideo.jp';
-  }
   get nAirLogin() {
     if (process.env.NAIR_LOGIN_URL) {
       return process.env.NAIR_LOGIN_URL;

--- a/app/services/hosts.ts
+++ b/app/services/hosts.ts
@@ -18,6 +18,9 @@ export class HostsService extends Service {
   get niconicolive() {
     return 'http://live.nicovideo.jp';
   }
+  get niconicoRelive() {
+    return 'http://live2.nicovideo.jp';
+  }
   get nAirLogin() {
     if (process.env.NAIR_LOGIN_URL) {
       return process.env.NAIR_LOGIN_URL;

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -13,7 +13,7 @@ import {
   FilterRecord,
   OnairUserProgramData,
   OnairChannelProgramData,
-  OnairChannelsData,
+  OnairChannelData,
   BroadcastStreamData
 } from './ResponseTypes';
 import { addClipboardMenu } from 'util/addClipboardMenu';
@@ -433,7 +433,7 @@ export class NicoliveClient {
   /**
    * 放送可能なチャンネル一覧を取得する 
    */
-  async fetchOnairChannels(): Promise<OnairChannelsData[]> {
+  async fetchOnairChannels(): Promise<OnairChannelData[]> {
     const url = `${NicoliveClient.live2BaseURL}/unama/tool/v2/onairs/channels`
     const headers = new Headers();
     const userSession = await this.fetchSession();
@@ -444,7 +444,7 @@ export class NicoliveClient {
       return await fetch(request)
         .then(handleErrors)
         .then(response => response.json())
-        .then(json => { return json.data as OnairChannelsData[] });
+        .then(json => { return json.data as OnairChannelData[] });
     } catch {
       return Promise.resolve([]);
     }

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -10,9 +10,14 @@ import {
   CommonErrorResponse,
   Community,
   Filters,
-  FilterRecord
+  FilterRecord,
+  OnairUserProgramData,
+  OnairChannelProgramData,
+  OnairChannelsData,
+  BroadcastStreamData
 } from './ResponseTypes';
 import { addClipboardMenu } from 'util/addClipboardMenu';
+import { handleErrors } from 'util/requests';
 const { BrowserWindow } = remote;
 
 export enum CreateResult {
@@ -94,7 +99,7 @@ export class NicoliveClient {
     let obj: any = null;
     try {
       obj = JSON.parse(body);
-    } catch(e) {
+    } catch (e) {
       // bodyがJSONになってない異常失敗
 
       // breadcrumbsに載るようにログ
@@ -394,6 +399,87 @@ export class NicoliveClient {
       ok: false,
       value: obj as CommonErrorResponse,
     };
+  }
+  /*
+   * 放送可能なユーザー番組IDを取得する 
+   * 放送可能な番組がない場合はundefinedを返す
+   */
+  async fetchOnairUserProgram(): Promise<OnairUserProgramData | undefined> {
+    const url = `${NicoliveClient.live2BaseURL}/unama/tool/v2/onairs/user`
+    const headers = new Headers();
+    const userSession = await this.fetchSession();
+    headers.append('X-niconico-session', userSession);
+    const request = new Request(url, { headers });
+    try {
+      return fetch(request).then(handleErrors).then(response => response.json()).then(json => json.data);
+    } catch {
+      return Promise.resolve(undefined);
+    }
+  }
+
+  /**
+   * 放送可能なチャンネル番組IDを取得する 
+   * @param channelId チャンネルID(例： ch12345)
+   */
+  async fetchOnairChannelProgram(channelId: string): Promise<OnairChannelProgramData> {
+    const url = `${NicoliveClient.live2BaseURL}/unama/tool/v2/onairs/channels/${channelId}`
+    const headers = new Headers();
+    const userSession = await this.fetchSession();
+    headers.append('X-niconico-session', userSession);
+    const request = new Request(url, { headers });
+    return fetch(request).then(handleErrors).then(response => response.json().then(json => json.data));
+  }
+
+  /**
+   * 放送可能なチャンネル一覧を取得する 
+   */
+  async fetchOnairChannnels(): Promise<OnairChannelsData> {
+    const url = `${NicoliveClient.live2BaseURL}/unama/tool/v2/onairs/channels`
+    const headers = new Headers();
+    const userSession = await this.fetchSession();
+    headers.append('X-niconico-session', userSession);
+    const request = new Request(url, { headers });
+    // 取得できなかった場合も空配列を返す
+    try {
+      return fetch(request)
+        .then(handleErrors)
+        .then(response => response.json())
+        .then(json => { return json.data as OnairChannelsData });
+    } catch {
+      return Promise.resolve([]);
+    }
+  }
+
+  /**
+   * 指定番組IDのストリーム情報を取得する 
+   * @param programId 番組ID(例： lv12345)
+   */
+  async fetchBroadcastStream(programId: string): Promise<BroadcastStreamData> {
+    const url = `${NicoliveClient.live2BaseURL}/unama/api/v2/programs/${programId}/broadcast_stream`;
+    const headers = new Headers();
+    const userSession = await this.fetchSession();
+    headers.append('X-niconico-session', userSession);
+    const request = new Request(url, { headers });
+    return fetch(request).then(handleErrors).then(response => response.json()).then(json => json.data);
+  }
+
+  async fetchMaxBitrate(programId: string): Promise<number> {
+    const programInformation = await this.fetchProgram(programId);
+    if (!isOk(programInformation)) {
+      return 192;
+    }
+    switch (programInformation.value.streamSetting.maxQuality) {
+      case '6Mbps720p':
+        return 6000;
+      case '2Mbps450p':
+        return 2000;
+      case '1Mbps450p':
+        return 1000;
+      case '384kbps288p':
+        return 384;
+      case '192kbps288p':
+        return 192;
+    }
   }
 
   /** 番組作成画面を開いて結果を返す */

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -433,7 +433,7 @@ export class NicoliveClient {
   /**
    * 放送可能なチャンネル一覧を取得する 
    */
-  async fetchOnairChannnels(): Promise<OnairChannelsData> {
+  async fetchOnairChannels(): Promise<OnairChannelsData> {
     const url = `${NicoliveClient.live2BaseURL}/unama/tool/v2/onairs/channels`
     const headers = new Headers();
     const userSession = await this.fetchSession();

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -433,7 +433,7 @@ export class NicoliveClient {
   /**
    * 放送可能なチャンネル一覧を取得する 
    */
-  async fetchOnairChannels(): Promise<OnairChannelsData> {
+  async fetchOnairChannels(): Promise<OnairChannelsData[]> {
     const url = `${NicoliveClient.live2BaseURL}/unama/tool/v2/onairs/channels`
     const headers = new Headers();
     const userSession = await this.fetchSession();
@@ -444,7 +444,7 @@ export class NicoliveClient {
       return fetch(request)
         .then(handleErrors)
         .then(response => response.json())
-        .then(json => { return json.data as OnairChannelsData });
+        .then(json => { return json.data as OnairChannelsData[] });
     } catch {
       return Promise.resolve([]);
     }

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -411,7 +411,7 @@ export class NicoliveClient {
     headers.append('X-niconico-session', userSession);
     const request = new Request(url, { headers });
     try {
-      return fetch(request).then(handleErrors).then(response => response.json()).then(json => json.data);
+      return await fetch(request).then(handleErrors).then(response => response.json()).then(json => json.data);
     } catch {
       return Promise.resolve(undefined);
     }
@@ -441,7 +441,7 @@ export class NicoliveClient {
     const request = new Request(url, { headers });
     // 取得できなかった場合も空配列を返す
     try {
-      return fetch(request)
+      return await fetch(request)
         .then(handleErrors)
         .then(response => response.json())
         .then(json => { return json.data as OnairChannelsData[] });

--- a/app/services/nicolive-program/ResponseTypes.ts
+++ b/app/services/nicolive-program/ResponseTypes.ts
@@ -44,6 +44,10 @@ export interface ProgramInfo {
           name: string;
           /** コミュニティID */
           id: string;
+          /** コミュレベル */
+          communityLevel: number;
+          /** サムネイルのURL */
+          thumbnailUrl: string;
         }
       | {
           providerType: 'channel';
@@ -53,8 +57,8 @@ export interface ProgramInfo {
           id: string;
           /** 配信会社名 */
           ownerName: string;
-          /** コミュレベル */
-          communityLevel: number;
+          /** サムネイルのURL */
+          thumbnailUrl: string;
         };
     /** コメントのルーム */
     rooms: {
@@ -92,6 +96,13 @@ export interface ProgramInfo {
       /** 配信者/配信会社名 */
       name: string;
     }[];
+    /** ストリーム設定 */
+    streamSetting: {
+      /** 配信最高画質 */
+      maxQuality: '6Mbps720p' | '2Mbps450p' | '1Mbps450p' | '384kbps288p' | '192kbps288p';
+      /** 配信の向き */
+      orientation: 'Landscape' | 'Portrait';
+    }
   };
 }
 

--- a/app/services/nicolive-program/ResponseTypes.ts
+++ b/app/services/nicolive-program/ResponseTypes.ts
@@ -227,7 +227,7 @@ export type OnairChannelsData = {
   ownerName: string;
   thumbnailUrl: string;
   smallThumbnailUrl: string;
-}[];
+};
 
 export type BroadcastStreamData = {
   url: string;

--- a/app/services/nicolive-program/ResponseTypes.ts
+++ b/app/services/nicolive-program/ResponseTypes.ts
@@ -209,3 +209,27 @@ export interface Filters {
   };
   data: FilterRecord[];
 }
+
+export type OnairUserProgramData = {
+  programId?: string;
+  nextProgramId?: string;
+}
+
+export type OnairChannelProgramData = {
+  testProgramId?: string;
+  programId?: string;
+  nextProgramId?: string;
+}
+
+export type OnairChannelsData = {
+  id: string;
+  name: string;
+  ownerName: string;
+  thumbnailUrl: string;
+  smallThumbnailUrl: string;
+}[];
+
+export type BroadcastStreamData = {
+  url: string;
+  name: string;
+}

--- a/app/services/nicolive-program/ResponseTypes.ts
+++ b/app/services/nicolive-program/ResponseTypes.ts
@@ -221,7 +221,7 @@ export type OnairChannelProgramData = {
   nextProgramId?: string;
 }
 
-export type OnairChannelsData = {
+export type OnairChannelData = {
   id: string;
   name: string;
   ownerName: string;

--- a/app/services/platforms/__snapshots__/niconico.test.ts.snap
+++ b/app/services/platforms/__snapshots__/niconico.test.ts.snap
@@ -25,31 +25,6 @@ Array [
 ]
 `;
 
-exports[`setupStreamSettingsで番組がひとつある場合 1`] = `
-Array [
-  "Stream",
-  Array [
-    Object {
-      "nameSubCategory": "Untitled",
-      "parameters": Array [
-        Object {
-          "name": "service",
-          "value": "niconico ニコニコ生放送",
-        },
-        Object {
-          "name": "server",
-          "value": "url1",
-        },
-        Object {
-          "name": "key",
-          "value": "key1",
-        },
-      ],
-    },
-  ],
-]
-`;
-
 exports[`setupStreamSettingsで番組取得にリトライで成功する場合 1`] = `
 Array [
   "Stream",

--- a/app/services/platforms/__snapshots__/niconico.test.ts.snap
+++ b/app/services/platforms/__snapshots__/niconico.test.ts.snap
@@ -25,64 +25,6 @@ Array [
 ]
 `;
 
-exports[`setupStreamSettingsで番組が複数ある場合 2`] = `
-Array [
-  Object {
-    "componentName": "NicoliveProgramSelector",
-    "queryParams": Object {
-      "channels": Array [
-        Object {
-          "broadcastablePrograms": Array [
-            Object {
-              "id": "lv1111111111",
-            },
-            Object {
-              "id": "lv2222222222",
-            },
-          ],
-          "id": "ch1",
-          "name": "テスト用チャンネル1",
-          "thumbnailUrl": "https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg",
-          "type": "channel",
-        },
-        Object {
-          "broadcastablePrograms": Array [
-            Object {
-              "id": "lv4444444444",
-            },
-            Object {
-              "id": "lv5555555555",
-            },
-          ],
-          "id": "ch2",
-          "name": "テスト用チャンネル2",
-          "thumbnailUrl": "https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg",
-          "type": "channel",
-        },
-      ],
-      "community": Object {
-        "broadcastablePrograms": Array [
-          Object {
-            "id": "lv1",
-          },
-          Object {
-            "id": "lv2",
-          },
-        ],
-        "id": "co1",
-        "name": "テスト用コミュニティ",
-        "thumbnailUrl": "https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg",
-        "type": "community",
-      },
-    },
-    "size": Object {
-      "height": 800,
-      "width": 800,
-    },
-  },
-]
-`;
-
 exports[`setupStreamSettingsで番組取得にリトライで成功する場合 1`] = `
 Array [
   "Stream",

--- a/app/services/platforms/__snapshots__/niconico.test.ts.snap
+++ b/app/services/platforms/__snapshots__/niconico.test.ts.snap
@@ -1,5 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`setupStreamSettingsでストリーム情報がとれた場合 1`] = `
+Array [
+  "Stream",
+  Array [
+    Object {
+      "nameSubCategory": "Untitled",
+      "parameters": Array [
+        Object {
+          "name": "service",
+          "value": "niconico ニコニコ生放送",
+        },
+        Object {
+          "name": "server",
+          "value": "url1",
+        },
+        Object {
+          "name": "key",
+          "value": "key1",
+        },
+      ],
+    },
+  ],
+]
+`;
+
 exports[`setupStreamSettingsで番組がひとつある場合 1`] = `
 Array [
   "Stream",

--- a/app/services/platforms/index.ts
+++ b/app/services/platforms/index.ts
@@ -19,8 +19,6 @@ export interface IPlatformService {
 
   fetchViewerCount: () => Promise<number>;
 
-  getChatUrl: (mode: string) => Promise<string>;
-
   isLoggedIn?: () => Promise<boolean>;
   logout?: () => Promise<void>;
 

--- a/app/services/platforms/index.ts
+++ b/app/services/platforms/index.ts
@@ -1,7 +1,6 @@
 import { NiconicoService } from './niconico';
 
 export type IStreamingSetting = {
-  asking: boolean,
   url: string,
   key: string,
   bitrate: number | undefined

--- a/app/services/platforms/niconico.test.ts
+++ b/app/services/platforms/niconico.test.ts
@@ -1,5 +1,4 @@
 import { createSetupFunction } from 'util/test-setup';
-type NiconicoServise = import('./niconico').NiconicoService
 
 const setup = createSetupFunction({
   injectee: {
@@ -30,30 +29,6 @@ jest.mock('services/i18n', () => ({
   $t: (x: any) => x,
 }));
 
-const community = {
-  providerType: 'community',
-  name: 'community name',
-  id: 'co12345',
-  communityLevel: 1,
-  thumbnailUrl: 'thumbnail url',
-}
-const channel1 = {
-  providerType: 'channel',
-  name: 'channel name1',
-  id: 'ch12345',
-  ownerName: 'owner1',
-  thumbnailUrl: 'thumbnail url1',
-  smallThumbnailUrl: 'small thumbnail url1',
-}
-const channel2 = {
-  providerType: 'channel',
-  name: 'channel name2',
-  id: 'ch123456',
-  ownerName: 'owner2',
-  thumbnailUrl: 'thumbnail url2',
-  smallThumbnailUrl: 'small thumbnail url2',
-}
-
 beforeEach(() => {
   jest.resetModules();
 });
@@ -64,21 +39,7 @@ test('get instance', () => {
   expect(NiconicoService.instance).toBeInstanceOf(NiconicoService);
 });
 
-test('setupStreamSettingsで番組がない場合', async () => {
-  setup();
-  const { NiconicoService } = require('./niconico');
-  const { instance } = NiconicoService;
-
-  instance.fetchLiveProgramInfo = jest.fn().mockResolvedValue({});
-  instance.client.fetchProgram = jest.fn();
-
-  const result = await instance.setupStreamSettings();
-  expect(result.url).toEqual('');
-  expect(result.asking).toBe(false);
-  expect(instance.fetchLiveProgramInfo).toHaveBeenCalledTimes(2);
-});
-
-test('setupStreamSettingsで番組がひとつある場合', async () => {
+test('setupStreamSettingsでストリーム情報がとれた場合', async () => {
   const updatePlatformChannelId = jest.fn();
   const getSettingsFormData = jest.fn();
   const setSettings = jest.fn();
@@ -108,40 +69,16 @@ test('setupStreamSettingsで番組がひとつある場合', async () => {
   const { NiconicoService } = require('./niconico');
   const { instance } = NiconicoService;
 
-  instance.fetchOnairUserProgram = jest.fn(() => Promise.resolve({
-    programId: 'lv12345'
-  }));
-  instance.fetchOnairChannnels = jest.fn(() => Promise.resolve([]))
-  instance.fetchOnairChannelProgram = jest.fn((channelId: string) => Promise.reject())
-  instance.client.fetchProgram = jest.fn((programId: string) => Promise.resolve({
-    ok: true,
-    value: {
-      socialGroup: community
-    }
-  }));
-  instance.fetchBroadcastStream = jest.fn((programId: string) => Promise.resolve({
+  instance.client.fetchBroadcastStream = jest.fn((programId: string) => Promise.resolve({
     url: 'url1',
     name: 'key1'
   }));
-  instance.fetchMaxBitrate = jest.fn((programId: string) => Promise.resolve(6000));
+  instance.client.fetchMaxBitrate = jest.fn((programId: string) => Promise.resolve(6000));
 
-  const programInfo = await instance.fetchLiveProgramInfo();
-  const result = await instance.setupStreamSettings();
-  expect(programInfo).toEqual({
-    community: {
-      type: 'community',
-      id: community.id,
-      name: community.name,
-      thumbnailUrl: community.thumbnailUrl,
-      broadcastablePrograms: [{ id: 'lv12345' }]
-    },
-    channels: undefined
-  });
+  const result = await instance.setupStreamSettings('lv12345');
   expect(result.url).toBe('url1');
   expect(result.key).toBe('key1');
   expect(result.bitrate).toBe(6000);
-  expect(updatePlatformChannelId).toHaveBeenCalledTimes(1);
-  expect(updatePlatformChannelId).toHaveBeenLastCalledWith('co12345');
   expect(setSettings).toHaveBeenCalledTimes(1);
   expect(setSettings.mock.calls[0]).toMatchSnapshot();
 });
@@ -167,123 +104,18 @@ test('setupStreamSettingsで番組取得にリトライで成功する場合', a
   const { NiconicoService } = require('./niconico');
   const { instance } = NiconicoService;
 
-  instance.fetchLiveProgramInfo = jest
-    .fn()
-    .mockReturnValueOnce(Promise.resolve({}))
-    .mockResolvedValue({
-      community: {
-        type: 'community',
-        id: community.id,
-        name: community.name,
-        thumbnailUrl: community.thumbnailUrl,
-        broadcastablePrograms: [{ id: 'lv12345' }]
-      },
-      channels: undefined,
-    });
-  instance.fetchBroadcastStream = jest.fn((programId: string) => Promise.resolve({
+  instance.client.fetchBroadcastStream = jest.fn((programId: string) => Promise.resolve({
     url: 'url1',
     name: 'key1'
   }))
-  instance.fetchMaxBitrate = jest.fn((programId: string) => Promise.resolve(6000));
+  instance.client.fetchMaxBitrate = jest.fn((programId: string) => Promise.resolve(6000));
 
   const result = await instance.setupStreamSettings();
   expect(result).toEqual({
-    asking: false,
     url: 'url1',
     key: 'key1',
     bitrate: 6000,
   });
-  expect(updatePlatformChannelId).toHaveBeenCalledTimes(1);
-  expect(updatePlatformChannelId).toHaveBeenLastCalledWith(community.id);
   expect(setSettings).toHaveBeenCalledTimes(1);
   expect(setSettings.mock.calls[0]).toMatchSnapshot();
-});
-
-test('setupStreamSettingsでチャンネル番組が複数ある場合', async () => {
-  const updatePlatformChannelId = jest.fn();
-  const getSettingsFormData = jest.fn();
-  const setSettings = jest.fn();
-  const showWindow = jest.fn();
-
-  getSettingsFormData.mockReturnValue([
-    {
-      nameSubCategory: 'Untitled',
-      parameters: [{ name: 'service', value: '' }, { name: 'server', value: '' }, { name: 'key', value: '' }],
-    },
-  ]);
-
-  const injectee = {
-    UserService: {
-      updatePlatformChannelId,
-    },
-    SettingsService: {
-      getSettingsFormData,
-      setSettings,
-    },
-    WindowsService: {
-      showWindow: showWindow,
-    },
-  };
-
-  setup({ injectee });
-  const { NiconicoService } = require('./niconico');
-  const { instance } = NiconicoService;
-
-  instance.fetchOnairUserProgram = jest.fn(() => Promise.reject());
-  instance.fetchOnairChannnels = jest.fn(() => Promise.resolve([
-    {
-      id: channel1.id,
-      name: channel1.name,
-      ownerName: channel1.ownerName,
-      thumbnailUrl: channel1.thumbnailUrl,
-      smallThumbnailUrl: channel1.smallThumbnailUrl,
-
-    },
-    {
-      id: channel2.id,
-      name: channel2.name,
-      ownerName: channel2.ownerName,
-      thumbnailUrl: channel2.thumbnailUrl,
-      smallThumbnailUrl: channel2.smallThumbnailUrl,
-    }
-  ]))
-  instance.fetchOnairChannelProgram = jest.fn((channelId: string) => {
-    return channelId === channel1.id
-      ? Promise.resolve({ programId: 'lv12345' })
-      : Promise.resolve({ programId: 'lv123' });
-  })
-  instance.client.fetchProgram = jest.fn((programId: string) => Promise.reject());
-  instance.fetchBroadcastStream = jest.fn((programId: string) => Promise.resolve({
-    url: 'url1',
-    name: 'key1'
-  }))
-  instance.fetchMaxBitrate = jest.fn((programId: string) => Promise.resolve(6000));
-
-  const programInfo = await instance.fetchLiveProgramInfo();
-  const result = await instance.setupStreamSettings();
-  expect(programInfo).toEqual({
-    community: undefined,
-    channels: [
-      {
-        type: 'channel',
-        id: channel1.id,
-        name: channel1.name,
-        thumbnailUrl: channel1.thumbnailUrl,
-        broadcastablePrograms: [{ id: 'lv12345' }]
-      },
-      {
-        type: 'channel',
-        id: channel2.id,
-        name: channel2.name,
-        thumbnailUrl: channel2.thumbnailUrl,
-        broadcastablePrograms: [{ id: 'lv123' }]
-      }
-    ],
-  })
-  expect(result.asking).toBe(true);
-  expect(result.url).toBe('');
-  expect(result.key).toBe('');
-  expect(result.bitrate).toBe(undefined);
-  expect(updatePlatformChannelId).toHaveBeenCalledTimes(0);
-  expect(setSettings).toHaveBeenCalledTimes(0);
 });

--- a/app/services/platforms/niconico.test.ts
+++ b/app/services/platforms/niconico.test.ts
@@ -1,4 +1,5 @@
 import { createSetupFunction } from 'util/test-setup';
+type NiconicoServise = import('./niconico').NiconicoService
 
 const setup = createSetupFunction({
   injectee: {
@@ -7,7 +8,7 @@ const setup = createSetupFunction({
     UserService: {},
     StreamingService: {
       streamingStatusChange: {
-        subscribe() {},
+        subscribe() { },
       },
     },
     WindowsService: {},
@@ -23,6 +24,35 @@ jest.mock('services/windows', () => ({}));
 jest.mock('util/sleep', () => ({
   sleep: () => jest.requireActual('util/sleep').sleep(0),
 }));
+jest.mock('util/menus/Menu', () => ({}));
+jest.mock('services/sources');
+jest.mock('services/i18n', () => ({
+  $t: (x: any) => x,
+}));
+
+const community = {
+  providerType: 'community',
+  name: 'community name',
+  id: 'co12345',
+  communityLevel: 1,
+  thumbnailUrl: 'thumbnail url',
+}
+const channel1 = {
+  providerType: 'channel',
+  name: 'channel name1',
+  id: 'ch12345',
+  ownerName: 'owner1',
+  thumbnailUrl: 'thumbnail url1',
+  smallThumbnailUrl: 'small thumbnail url1',
+}
+const channel2 = {
+  providerType: 'channel',
+  name: 'channel name2',
+  id: 'ch123456',
+  ownerName: 'owner2',
+  thumbnailUrl: 'thumbnail url2',
+  smallThumbnailUrl: 'small thumbnail url2',
+}
 
 beforeEach(() => {
   jest.resetModules();
@@ -40,6 +70,7 @@ test('setupStreamSettingsで番組がない場合', async () => {
   const { instance } = NiconicoService;
 
   instance.fetchLiveProgramInfo = jest.fn().mockResolvedValue({});
+  instance.client.fetchProgram = jest.fn();
 
   const result = await instance.setupStreamSettings();
   expect(result.url).toEqual('');
@@ -51,6 +82,7 @@ test('setupStreamSettingsで番組がひとつある場合', async () => {
   const updatePlatformChannelId = jest.fn();
   const getSettingsFormData = jest.fn();
   const setSettings = jest.fn();
+  const showWindow = jest.fn();
 
   getSettingsFormData.mockReturnValue([
     {
@@ -67,24 +99,49 @@ test('setupStreamSettingsで番組がひとつある場合', async () => {
       getSettingsFormData,
       setSettings,
     },
+    WindowsService: {
+      showWindow: showWindow,
+    },
   };
 
   setup({ injectee });
   const { NiconicoService } = require('./niconico');
   const { instance } = NiconicoService;
 
-  instance.fetchLiveProgramInfo = jest.fn().mockResolvedValue({
-    channelId: {
-      url: 'url1',
-      key: 'key1',
-      bitrate: 'bitrate1',
-    },
-  });
+  instance.fetchOnairUserProgram = jest.fn(() => Promise.resolve({
+    programId: 'lv12345'
+  }));
+  instance.fetchOnairChannnels = jest.fn(() => Promise.resolve([]))
+  instance.fetchOnairChannelProgram = jest.fn((channelId: string) => Promise.reject())
+  instance.client.fetchProgram = jest.fn((programId: string) => Promise.resolve({
+    ok: true,
+    value: {
+      socialGroup: community
+    }
+  }));
+  instance.fetchBroadcastStream = jest.fn((programId: string) => Promise.resolve({
+    url: 'url1',
+    name: 'key1'
+  }));
+  instance.fetchMaxBitrate = jest.fn((programId: string) => Promise.resolve(6000));
 
+  const programInfo = await instance.fetchLiveProgramInfo();
   const result = await instance.setupStreamSettings();
+  expect(programInfo).toEqual({
+    community: {
+      type: 'community',
+      id: community.id,
+      name: community.name,
+      thumbnailUrl: community.thumbnailUrl,
+      broadcastablePrograms: [{ id: 'lv12345' }]
+    },
+    channels: undefined
+  });
   expect(result.url).toBe('url1');
+  expect(result.key).toBe('key1');
+  expect(result.bitrate).toBe(6000);
   expect(updatePlatformChannelId).toHaveBeenCalledTimes(1);
-  expect(updatePlatformChannelId).toHaveBeenLastCalledWith('channelId');
+  expect(updatePlatformChannelId).toHaveBeenLastCalledWith('co12345');
   expect(setSettings).toHaveBeenCalledTimes(1);
   expect(setSettings.mock.calls[0]).toMatchSnapshot();
 });
@@ -114,27 +171,35 @@ test('setupStreamSettingsで番組取得にリトライで成功する場合', a
     .fn()
     .mockReturnValueOnce(Promise.resolve({}))
     .mockResolvedValue({
-      channelId: {
-        url: 'url1',
-        key: 'key1',
-        bitrate: 'bitrate1',
+      community: {
+        type: 'community',
+        id: community.id,
+        name: community.name,
+        thumbnailUrl: community.thumbnailUrl,
+        broadcastablePrograms: [{ id: 'lv12345' }]
       },
+      channels: undefined,
     });
+  instance.fetchBroadcastStream = jest.fn((programId: string) => Promise.resolve({
+    url: 'url1',
+    name: 'key1'
+  }))
+  instance.fetchMaxBitrate = jest.fn((programId: string) => Promise.resolve(6000));
 
   const result = await instance.setupStreamSettings();
   expect(result).toEqual({
     asking: false,
     url: 'url1',
     key: 'key1',
-    bitrate: 'bitrate1',
+    bitrate: 6000,
   });
   expect(updatePlatformChannelId).toHaveBeenCalledTimes(1);
-  expect(updatePlatformChannelId).toHaveBeenLastCalledWith('channelId');
+  expect(updatePlatformChannelId).toHaveBeenLastCalledWith(community.id);
   expect(setSettings).toHaveBeenCalledTimes(1);
   expect(setSettings.mock.calls[0]).toMatchSnapshot();
 });
 
-test('setupStreamSettingsで番組が複数ある場合', async () => {
+test('setupStreamSettingsでチャンネル番組が複数ある場合', async () => {
   const updatePlatformChannelId = jest.fn();
   const getSettingsFormData = jest.fn();
   const setSettings = jest.fn();
@@ -149,11 +214,11 @@ test('setupStreamSettingsで番組が複数ある場合', async () => {
 
   const injectee = {
     UserService: {
-      updatePlatformChannelId: updatePlatformChannelId,
+      updatePlatformChannelId,
     },
     SettingsService: {
-      getSettingsFormData: getSettingsFormData,
-      setSettings: setSettings,
+      getSettingsFormData,
+      setSettings,
     },
     WindowsService: {
       showWindow: showWindow,
@@ -164,23 +229,61 @@ test('setupStreamSettingsで番組が複数ある場合', async () => {
   const { NiconicoService } = require('./niconico');
   const { instance } = NiconicoService;
 
-  const info = {
-    channelId1: { url: 'url1', key: 'key1', bitrate: 'bitrate1' },
-    channelId2: { url: 'url2', key: 'key2', bitrate: 'bitrate2' },
-  };
-  instance.fetchLiveProgramInfo = jest.fn().mockResolvedValue(info);
+  instance.fetchOnairUserProgram = jest.fn(() => Promise.reject());
+  instance.fetchOnairChannnels = jest.fn(() => Promise.resolve([
+    {
+      id: channel1.id,
+      name: channel1.name,
+      ownerName: channel1.ownerName,
+      thumbnailUrl: channel1.thumbnailUrl,
+      smallThumbnailUrl: channel1.smallThumbnailUrl,
 
+    },
+    {
+      id: channel2.id,
+      name: channel2.name,
+      ownerName: channel2.ownerName,
+      thumbnailUrl: channel2.thumbnailUrl,
+      smallThumbnailUrl: channel2.smallThumbnailUrl,
+    }
+  ]))
+  instance.fetchOnairChannelProgram = jest.fn((channelId: string) => {
+    return channelId === channel1.id
+      ? Promise.resolve({ programId: 'lv12345' })
+      : Promise.resolve({ programId: 'lv123' });
+  })
+  instance.client.fetchProgram = jest.fn((programId: string) => Promise.reject());
+  instance.fetchBroadcastStream = jest.fn((programId: string) => Promise.resolve({
+    url: 'url1',
+    name: 'key1'
+  }))
+  instance.fetchMaxBitrate = jest.fn((programId: string) => Promise.resolve(6000));
+
+  const programInfo = await instance.fetchLiveProgramInfo();
   const result = await instance.setupStreamSettings();
-  expect(result).toMatchInlineSnapshot(`
-Object {
-  "asking": true,
-  "bitrate": undefined,
-  "key": "",
-  "url": "",
-}
-`);
-  expect(showWindow.mock.calls[0]).toMatchSnapshot();
-
-  expect(updatePlatformChannelId).not.toHaveBeenCalled();
-  expect(setSettings).not.toHaveBeenCalled();
+  expect(programInfo).toEqual({
+    community: undefined,
+    channels: [
+      {
+        type: 'channel',
+        id: channel1.id,
+        name: channel1.name,
+        thumbnailUrl: channel1.thumbnailUrl,
+        broadcastablePrograms: [{ id: 'lv12345' }]
+      },
+      {
+        type: 'channel',
+        id: channel2.id,
+        name: channel2.name,
+        thumbnailUrl: channel2.thumbnailUrl,
+        broadcastablePrograms: [{ id: 'lv123' }]
+      }
+    ],
+  })
+  expect(result.asking).toBe(true);
+  expect(result.url).toBe('');
+  expect(result.key).toBe('');
+  expect(result.bitrate).toBe(undefined);
+  expect(updatePlatformChannelId).toHaveBeenCalledTimes(0);
+  expect(setSettings).toHaveBeenCalledTimes(0);
 });

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -220,7 +220,6 @@ export class NiconicoService extends Service implements IPlatformService {
     const broadcastableComunityProgramNumber = info.community ? info.community.broadcastablePrograms.length : 0;
     const broadcastableChannnelProgramNumber = this.countBroadcastableChannelProgram(info.channels);
     const broadcastableProgramNumber = broadcastableComunityProgramNumber + broadcastableChannnelProgramNumber;
-    // const broadcastableprogramnumber = 2;
 
     // 配信可能番組がない場合
     if (broadcastableProgramNumber === 0) {

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -169,7 +169,7 @@ export class NiconicoService extends Service implements IPlatformService {
       return result;
     } catch (e) {
       // リトライは1回だけ
-      return NiconicoService.emptyStreamingSetting(false);
+      return NiconicoService.emptyStreamingSetting();
     }
   }
 
@@ -199,16 +199,16 @@ export class NiconicoService extends Service implements IPlatformService {
     this.settingsService.setSettings('Stream', settings);
 
     // 有効な番組が選択されているので stream keyを返す
-    return NiconicoService.createStreamingSetting(false, url, key, bitrate);
+    return NiconicoService.createStreamingSetting(url, key, bitrate);
   }
 
-  private static emptyStreamingSetting(asking: boolean): IStreamingSetting {
-    return NiconicoService.createStreamingSetting(asking, '', '');
+  private static emptyStreamingSetting(): IStreamingSetting {
+    return NiconicoService.createStreamingSetting('', '');
   }
 
-  private static createStreamingSetting(asking: boolean, url: string, key: string, bitrate?: number)
+  private static createStreamingSetting(url: string, key: string, bitrate?: number)
     : IStreamingSetting {
-    return { asking, url, key, bitrate };
+    return { url, key, bitrate };
   }
 
   // TODO ニコニコOAuthのtoken更新に使う

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -174,10 +174,12 @@ export class NiconicoService extends Service implements IPlatformService {
   }
 
   private async _setupStreamSettings(programId: string): Promise<IStreamingSetting> {
-    const stream = await this.client.fetchBroadcastStream(programId);
+    const [stream, bitrate] = await Promise.all([
+      this.client.fetchBroadcastStream(programId),
+      this.client.fetchMaxBitrate(programId)
+    ]);
     const url = stream.url;
     const key = stream.name;
-    const bitrate = await this.client.fetchMaxBitrate(programId);
 
     const settings = this.settingsService.getSettingsFormData('Stream');
     settings.forEach(subCategory => {

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -226,42 +226,6 @@ export class NiconicoService extends Service implements IPlatformService {
   }
 
   /**
-
-  async fetchBroadcastableProgramId(): Promise<string | undefined> {
-    const broadcastableUserProgramId = await this.fetchOnairUserProgram();
-    const broadcastableChannelId = await this.fetchOnairChannnels();
-    console.log('=================userprogram', broadcastableUserProgramId);
-    console.log('=================channel', broadcastableChannelId);
-    // 配信可能な番組がない場合
-    if (!broadcastableUserProgramId.programId && broadcastableChannelId.length === 0) {
-      return Promise.reject("no program");
-    }
-
-    // ユーザ番組のみ配信可能
-    if (broadcastableUserProgramId.programId && broadcastableChannelId.length === 0) {
-      console.log('=========================user only')
-      return broadcastableUserProgramId.programId;
-    }
-
-    // 配信可能なユーザ番組がないが配信可能なチャンネルがある場合
-    if (!broadcastableUserProgramId.programId && broadcastableChannelId.length > 0) {
-      const broadcastableChannelProgramId = await this.fetchOnairChannelProgram(broadcastableChannelId[0].id);
-      const programIds = Object.keys(broadcastableChannelProgramId).map((key) => {
-        return broadcastableChannelProgramId[key];
-      });
-      // 配信可能なチャンネル番組が一つだけの場合
-      if (programIds.length === 1) {
-        return programIds[0];
-      } else {
-        return undefined;
-      }
-    }
-
-    // 配信可能なユーザ番組があり、配信可能なチャンネルがある場合
-    return undefined;
-  }
-
-  /**
    * getplayerstatusを叩く
    * 将来的にAPIはN Air向けのものに移行する予定で、暫定的な実装
    */

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -447,6 +447,7 @@ export class NiconicoService extends Service implements IPlatformService {
         }
       }, undefined);
       if (matchedChannel) {
+        matchedChannel.broadcastablePrograms = [{ id: programId }]
         return {
           channels: [matchedChannel]
         };

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -313,7 +313,7 @@ export class NiconicoService extends Service implements IPlatformService {
    * @param channelId チャンネルID(例： ch12345)
    */
   private fetchOnairChannelProgram(channelId: string): Promise<OnairChannelProgramData> {
-    const url = `${this.hostsService.niconicoRelive}/unama/tool/v2/onairs/channels${channelId}`
+    const url = `${this.hostsService.niconicoRelive}/unama/tool/v2/onairs/channels/${channelId}`
     const headers = this.getHeaders();
     headers.append('X-niconico-session', this.userService.apiToken);
     const request = new Request(url, { headers });

--- a/app/services/streaming/streaming.test.ts
+++ b/app/services/streaming/streaming.test.ts
@@ -14,8 +14,10 @@ jest.mock('services/i18n', () => ({
 }));
 jest.mock('services/customization', () => ({}));
 jest.mock('services/user', () => ({}));
+jest.mock('util/menus/Menu', () => ({}));
 
-function noop() {}
+function noop() { }
+const showWindow = jest.fn();
 
 const createInjectee = ({
   OBS_service_startStreaming = noop,
@@ -58,6 +60,9 @@ const createInjectee = ({
   },
   CustomizationService: {
     optimizeForNiconico,
+  },
+  WindowsService: {
+    showWindow: showWindow,
   },
 });
 
@@ -376,6 +381,9 @@ test('toggleStreamingAsyncでstreamingStatusがoffline以外の場合', async ()
   const { StreamingService } = require('./streaming');
   const { instance } = StreamingService;
 
+  instance.client.fetchOnairUserProgram = jest.fn(() => Promise.resolve('lv12345'));
+  instance.client.fetchOnairChannels = jest.fn(() => Promise.resolve([]));
+
   instance.toggleStreaming = jest.fn();
 
   await instance.toggleStreamingAsync();
@@ -406,8 +414,8 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
   setup({
     injectee: createInjectee({
       isNiconicoLoggedIn: true,
-      updateStreamSettings() {
-        return { asking: true };
+      updateStreamSettings: () => {
+        return { url: '', name: '' };
       },
     }),
     state: {
@@ -419,6 +427,16 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
 
   const { StreamingService } = require('./streaming');
   const { instance } = StreamingService;
+  const channels = [{
+    id: 'id',
+    name: 'name',
+    ownerName: 'ownerName',
+    thumbnailUrl: 'thumbnailUrl',
+    smallThumbnailUrl: 'smallThumbnailUrl',
+  }];
+
+  instance.client.fetchOnairUserProgram = jest.fn(() => Promise.resolve({ programId: 'lv12345' }));
+  instance.client.fetchOnairChannels = jest.fn(() => Promise.resolve(channels));
 
   instance.toggleStreaming = jest.fn();
 
@@ -431,7 +449,7 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
   setup({
     injectee: createInjectee({
       isNiconicoLoggedIn: true,
-      updateStreamSettings() {
+      updateStreamSettings: () => {
         return { key: '' };
       },
     }),
@@ -444,6 +462,9 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
 
   const { StreamingService } = require('./streaming');
   const { instance } = StreamingService;
+
+  instance.client.fetchOnairUserProgram = jest.fn(() => Promise.resolve(undefined));
+  instance.client.fetchOnairChannels = jest.fn(() => Promise.resolve([]));
 
   instance.toggleStreaming = jest.fn();
   instance.optimizeForNiconicoAndStartStreaming = jest.fn();
@@ -464,7 +485,7 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
   setup({
     injectee: createInjectee({
       isNiconicoLoggedIn: true,
-      updateStreamSettings() {
+      updateStreamSettings: () => {
         return { key: 'hoge' };
       },
       optimizeForNiconico: true,
@@ -481,6 +502,9 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
   instance.optimizeForNiconicoAndStartStreaming = jest.fn();
   instance.toggleStreaming = jest.fn();
 
+  instance.client.fetchOnairUserProgram = jest.fn(() => Promise.resolve({ programId: 'lv12345' }));
+  instance.client.fetchOnairChannels = jest.fn(() => Promise.resolve([]));
+
   await instance.toggleStreamingAsync();
 
   expect(instance.optimizeForNiconicoAndStartStreaming).toHaveBeenCalledTimes(1);
@@ -491,7 +515,7 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
   setup({
     injectee: createInjectee({
       isNiconicoLoggedIn: true,
-      updateStreamSettings() {
+      updateStreamSettings: () => {
         return { key: 'hoge' };
       },
     }),
@@ -507,6 +531,9 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
   instance.toggleStreaming = jest.fn();
   instance.optimizeForNiconicoAndStartStreaming = jest.fn();
 
+  instance.client.fetchOnairUserProgram = jest.fn(() => Promise.resolve({ programId: 'lv12345' }));
+  instance.client.fetchOnairChannels = jest.fn(() => Promise.resolve([]));
+
   await instance.toggleStreamingAsync();
 
   expect(instance.optimizeForNiconicoAndStartStreaming).not.toHaveBeenCalled();
@@ -517,7 +544,7 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
   setup({
     injectee: createInjectee({
       isNiconicoLoggedIn: true,
-      updateStreamSettings() {
+      updateStreamSettings: () => {
         throw new Error('NetworkError');
       },
     }),
@@ -539,6 +566,9 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
   instance.toggleStreaming = jest.fn();
   instance.optimizeForNiconicoAndStartStreaming = jest.fn();
 
+  instance.client.fetchOnairUserProgram = jest.fn(() => Promise.resolve({ programId: 'lv12345' }));
+  instance.client.fetchOnairChannels = jest.fn(() => Promise.resolve([]));
+
   await instance.toggleStreamingAsync();
 
   expect(instance.optimizeForNiconicoAndStartStreaming).not.toHaveBeenCalled();
@@ -549,7 +579,7 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
   setup({
     injectee: createInjectee({
       isNiconicoLoggedIn: true,
-      updateStreamSettings() {
+      updateStreamSettings: () => {
         throw new Response('HTTPError', {
           statusText: 'Internal Server Error(stub)',
           status: 500,
@@ -573,6 +603,9 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
   const { instance } = StreamingService;
   instance.toggleStreaming = jest.fn();
   instance.optimizeForNiconicoAndStartStreaming = jest.fn();
+
+  instance.client.fetchOnairUserProgram = jest.fn(() => Promise.resolve({ programId: 'lv12345' }));
+  instance.client.fetchOnairChannels = jest.fn(() => Promise.resolve([]));
 
   await instance.toggleStreamingAsync();
 

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -143,7 +143,7 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
         this.SET_PROGRAM_FETCHING(true);
         const broadcastableUserProgram = await this.client.fetchOnairUserProgram();
         if (opts.programId === '') {
-          const broadcastableChannels = await this.client.fetchOnairChannnels();
+          const broadcastableChannels = await this.client.fetchOnairChannels();
           if (broadcastableChannels.length > 0) {
             this.windowsService.showWindow({
               componentName: 'NicoliveProgramSelector',
@@ -160,9 +160,6 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
         }
         const programId = opts.programId !== '' ? opts.programId : broadcastableUserProgram.programId;
         const setting = await this.userService.updateStreamSettings(programId);
-        if (setting.asking) {
-          return;
-        }
         const streamkey = setting.key;
         if (streamkey === '') {
           return this.showNotBroadcastingMessageBox();

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -368,7 +368,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
     }, 'RecentEvents');
   }
 
-  async updateStreamSettings(programId: string = ''): Promise<IStreamingSetting> {
+  async updateStreamSettings(programId: string): Promise<IStreamingSetting> {
     return await getPlatformService(this.platform.type).setupStreamSettings(programId);
   }
 


### PR DESCRIPTION
# このpull requestが解決する内容
getpublishstatus APIの利用をやめ新しいAPIに乗り換えました

# 動作確認手順

- [x]  ユーザー番組を作成した状態で配信開始ボタンを押すと放送できる
- [ ] チャンネル配信できる状態で配信開始できる
- [x] 放送できる番組が複数ある場合に選択ウインドウが出る

# 関連するIssue（あれば）

#442