### PR TITLE
feat(nicolive-program-selector): 番組とチャンネルを取得

### DIFF
--- a/app/components/nicolive-program-selector/Step.vue
+++ b/app/components/nicolive-program-selector/Step.vue
@@ -5,9 +5,7 @@
      <p>{{ description }} </p>
    </div>
    <div class="section">
-     <ul class="list">
-       <slot />
-     </ul>
+     <slot />
    </div>
   </div>
 </template>

--- a/app/components/windows/NicoliveProgramSelector.vue
+++ b/app/components/windows/NicoliveProgramSelector.vue
@@ -24,48 +24,61 @@
         v-if="currentStep === 'providerTypeSelect'"
         :class="'provider-type-select-step'"
         :title="getStepTitle(currentStep)"
-        :desciption="getStepDescription(currentStep)">
-        <li v-for="providerType in providerTypes" :key="providerType">
-          <a @click="onSelectProviderType(providerType)">
-            <p class="anchor-text">{{ getProviderTypeProgramText(providerType) }}</p>
-          </a>
-        </li>
+        :description="getStepDescription(currentStep)">
+        <ul class="list">
+          <li v-for="providerType in providerTypes" :key="providerType">
+            <a @click="onSelectProviderType(providerType)">
+              <p class="anchor-text">{{ getProviderTypeProgramText(providerType) }}</p>
+            </a>
+          </li>
+        </ul>
       </Step>
       <Step
         v-if="currentStep === 'channelSelect'"
-        :class="'broadcast-channel-select-step'"
+        :class="'channel-select-step'"
         :title="getStepTitle(currentStep)"
-        :desciption="getStepDescription(currentStep)">
-          <li v-for="channel in queryParams.channels" :key="channel.id" >
+        :description="getStepDescription(currentStep)">
+        <ul class="list">
+          <li v-for="channel in candidateChannels" :key="channel.id" >
             <a @click="onSelectChannel(channel.id, channel.name)">
               <img :src="channel.thumbnailUrl" :alt="channel.name" class="channel-thumbnail" />
               <p class="anchor-text">{{ channel.name }}</p>
             </a>
           </li>
+        </ul>
       </Step>
       <Step
           v-if="currentStep === 'programSelect'"
           :class="'program-select-step'"
           :title="getStepTitle(currentStep)"
-          :desciption="getStepDescription(currentStep)">
-          <li v-for="program in candidatePrograms" :key="program.id">
-            <a @click="onSelectBroadcastingProgram(program.id, program.title)" >
-              <p class="anchor-text">{{ program.title }}</p>
-              <p class="annotation">
-                <span class="lv">{{ program.id }}</span>
-              </p>
-            </a>
-          </li>
+          :description="getStepDescription(currentStep)">
+          <!-- 文言に改行タグ <br /> を含むため、 v-html で HTML を注入しています。-->
+          <div class="section"
+             v-if="canShowNoProgramsSection()"
+             v-html="$t('streaming.nicoliveProgramSelector.noChannelPrograms')"
+          />
+          <ul class="list" v-else>
+            <li v-for="program in candidatePrograms" :key="program.id">
+              <a @click="onSelectBroadcastingProgram(program.id, program.title)" >
+                <p class="anchor-text">{{ program.title }}</p>
+                <p class="annotation">
+                  <span class="lv">{{ program.id }}</span>
+                </p>
+              </a>
+            </li>
+          </ul>
       </Step>
       <Step
         v-if="currentStep === 'confirm'"
         :class="'confirm-step'"
         :title="getStepTitle(currentStep)"
-        :desciption="getStepDescription(currentStep)">
-          <li v-for="step in selectionSteps" :key="step">
-            <div class="caption">{{ getStepTitle(step) }}</div>
-            <div class="value">{{ getSelectedValueForDisplay(step) || '-' }}</div>
-          </li>
+        :description="getStepDescription(currentStep)">
+          <ul class="list">
+            <li v-for="step in selectionSteps" :key="step">
+              <div class="caption">{{ getStepTitle(step) }}</div>
+              <div class="value">{{ getSelectedValueForDisplay(step) || '-' }}</div>
+            </li>
+          </ul>
       </Step>
     </div>
   </div>

--- a/app/components/windows/NicoliveProgramSelector.vue.ts
+++ b/app/components/windows/NicoliveProgramSelector.vue.ts
@@ -133,7 +133,10 @@ export default class NicoliveProgramSelector extends Vue {
 
   ok(): void {
     this.streamingService.toggleStreamingAsync({
-      programId: this.nicoliveProgramSelectorService.state.selectedProgram.id
+      nicoliveProgramSelectorResult: {
+        providerType: this.nicoliveProgramSelectorService.state.selectedProviderType,
+        channelProgramId: this.nicoliveProgramSelectorService.state.selectedProgram.id ?? undefined
+      }
     });
 
     this.windowsService.closeChildWindow();

--- a/app/components/windows/NicoliveProgramSelector.vue.ts
+++ b/app/components/windows/NicoliveProgramSelector.vue.ts
@@ -96,7 +96,7 @@ export default class NicoliveProgramSelector extends Vue {
     const {
        selectedProviderType,
        selectedChannel,
-       selectedProgram
+       selectedChannelProgram
     } = this.nicoliveProgramSelectorService.state;
     switch (navItemStep) {
       case 'providerTypeSelect':
@@ -104,7 +104,7 @@ export default class NicoliveProgramSelector extends Vue {
       case 'channelSelect':
         return selectedChannel?.name || this.BLANK;
       case 'programSelect':
-        return selectedProgram?.title || this.BLANK;
+        return selectedChannelProgram?.title || this.BLANK;
     }
   }
 
@@ -135,7 +135,7 @@ export default class NicoliveProgramSelector extends Vue {
     this.streamingService.toggleStreamingAsync({
       nicoliveProgramSelectorResult: {
         providerType: this.nicoliveProgramSelectorService.state.selectedProviderType,
-        channelProgramId: this.nicoliveProgramSelectorService.state.selectedProgram.id ?? undefined
+        channelProgramId: this.nicoliveProgramSelectorService.state.selectedChannelProgram.id ?? undefined
       }
     });
 

--- a/app/components/windows/NicoliveProgramSelector.vue.ts
+++ b/app/components/windows/NicoliveProgramSelector.vue.ts
@@ -16,7 +16,6 @@ import {
   selectionSteps as _selectionSteps,
   TSelectionStep
 } from 'services/nicolive-program/nicolive-program-selector';
-import { LiveProgramInfo } from 'services/platforms/niconico';
 import { StreamingService } from 'services/streaming';
 import { $t } from 'services/i18n';
 
@@ -34,8 +33,6 @@ export default class NicoliveProgramSelector extends Vue {
   @Inject() windowsService: WindowsService;
   @Inject() streamingService: StreamingService;
 
-  queryParams = this.windowsService.getChildWindowOptions().queryParams as LiveProgramInfo;
-
   readonly providerTypes = _providerTypes;
   readonly steps = _steps;
   readonly selectionSteps = _selectionSteps;
@@ -51,6 +48,10 @@ export default class NicoliveProgramSelector extends Vue {
     this.nicoliveProgramSelectorService.backTo(step);
   }
 
+  get candidateChannels() {
+    return this.nicoliveProgramSelectorService.state.candidateChannels;
+  }
+
   get candidatePrograms() {
     return this.nicoliveProgramSelectorService.state.candidatePrograms;
   }
@@ -62,9 +63,7 @@ export default class NicoliveProgramSelector extends Vue {
     if (providerType === 'channel') {
       this.nicoliveProgramSelectorService.onSelectProviderTypeChannel();
     } else {
-      this.nicoliveProgramSelectorService.onSelectProviderTypeUser(
-        this.queryParams.community.id
-      );
+      this.nicoliveProgramSelectorService.onSelectProviderTypeUser();
     }
   }
 
@@ -72,8 +71,7 @@ export default class NicoliveProgramSelector extends Vue {
     if (this.nicoliveProgramSelectorService.state.isLoading) {
       return;
     }
-    const channel = this.queryParams.channels.find(channel => channel.id === id);
-    this.nicoliveProgramSelectorService.onSelectChannel(id, name, channel.broadcastablePrograms);
+    this.nicoliveProgramSelectorService.onSelectChannel(id, name);
   }
 
   onSelectBroadcastingProgram(id: string, title: string): void {
@@ -110,6 +108,13 @@ export default class NicoliveProgramSelector extends Vue {
     }
   }
 
+  canShowNoProgramsSection(): boolean {
+    return (
+      !this.nicoliveProgramSelectorService.state.isLoading &&
+      this.nicoliveProgramSelectorService.state.candidatePrograms.length <= 0
+    );
+  }
+
   getProviderTypeProgramText(providerType: TProviderType): string {
     return $t(`streaming.nicoliveProgramSelector.providerTypeProgram.${providerType}`);
   }
@@ -123,7 +128,7 @@ export default class NicoliveProgramSelector extends Vue {
   }
 
   getStepDescription(step: TStep): string {
-    return $t(`streaming.nicoliveProgramSelector.steps.${step}.desciption`);
+    return $t(`streaming.nicoliveProgramSelector.steps.${step}.description`);
   }
 
   ok(): void {

--- a/app/components/windows/NicoliveProgramSelector.vue.ts
+++ b/app/components/windows/NicoliveProgramSelector.vue.ts
@@ -14,7 +14,7 @@ import {
   providerTypes as _providerTypes,
   steps as _steps,
   selectionSteps as _selectionSteps,
-  TSelectionStep
+  TSelectionStep,
 } from 'services/nicolive-program/nicolive-program-selector';
 import { StreamingService } from 'services/streaming';
 import { $t } from 'services/i18n';
@@ -60,11 +60,7 @@ export default class NicoliveProgramSelector extends Vue {
     if (this.nicoliveProgramSelectorService.state.isLoading) {
       return;
     }
-    if (providerType === 'channel') {
-      this.nicoliveProgramSelectorService.onSelectProviderTypeChannel();
-    } else {
-      this.nicoliveProgramSelectorService.onSelectProviderTypeUser();
-    }
+    this.nicoliveProgramSelectorService.onSelectProviderType(providerType);
   }
 
   onSelectChannel(id: string, name: string): void {

--- a/app/components/windows/NicoliveProgramSelector.vue.ts
+++ b/app/components/windows/NicoliveProgramSelector.vue.ts
@@ -131,7 +131,7 @@ export default class NicoliveProgramSelector extends Vue {
     this.streamingService.toggleStreamingAsync({
       nicoliveProgramSelectorResult: {
         providerType: this.nicoliveProgramSelectorService.state.selectedProviderType,
-        channelProgramId: this.nicoliveProgramSelectorService.state.selectedChannelProgram.id ?? undefined
+        channelProgramId: this.nicoliveProgramSelectorService.state.selectedChannelProgram?.id ?? undefined
       }
     });
 

--- a/app/i18n/en-US/streaming.json
+++ b/app/i18n/en-US/streaming.json
@@ -39,8 +39,6 @@
   },
   "nicoliveProgramSelector": {
     "title": "Select a programs to start streaming on",
-    "description": "There is more than one candidate program.<br/>Select one of the programs to start streaming on.",
-    "cancel": "Cancel",
     "steps": {
       "providerTypeSelect": {
         "menuTitle": "",
@@ -67,6 +65,7 @@
       "channel": "",
       "user": ""
     },
+    "noChannelPrograms": "",
     "done": "Select a program"
   },
   "FPS": "FPS",

--- a/app/i18n/ja-JP/streaming.json
+++ b/app/i18n/ja-JP/streaming.json
@@ -39,8 +39,6 @@
   },
   "nicoliveProgramSelector": {
     "title": "配信番組の選択",
-    "description": "配信可能な番組が複数あります。<br/>配信する番組を選択してください。",
-    "cancel": "キャンセル",
     "steps": {
       "providerTypeSelect": {
         "menuTitle": "配信種別",
@@ -67,6 +65,7 @@
       "channel": "チャンネル番組",
       "user": "ユーザー番組"
     },
+    "noChannelPrograms": "指定されたチャンネルに配信可能な番組がありません。<br />番組を作成するか、正しいチャンネルが選択されているかを確認してください。",
     "done": "番組を決定して配信する"
   },
   "FPS": "フレームレート",

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -141,6 +141,7 @@ export class NicoliveClient {
     return new Promise((resolve, reject) =>
       session.cookies.get({ url: 'https://.nicovideo.jp', name: 'user_session' }, (err, cookies) => {
         if (err) return reject(err);
+        if (cookies.length < 1) return reject(new Error('cookie not found'));
         resolve(cookies[0].value);
       })
     );

--- a/app/services/nicolive-program/nicolive-program-selector.test.ts
+++ b/app/services/nicolive-program/nicolive-program-selector.test.ts
@@ -27,7 +27,7 @@ test('ユーザー番組を選んで配信開始のための番組情報を準�
 
   // 確認へ
   const programId = 'lv1111';
-  instance.onSelectProviderTypeUser(programId);
+  instance.onSelectProviderTypeUser();
   expect(instance.state.currentStep).toBe('confirm');
   expect(instance.state.selectedProviderType).toBe('user');
   expect(instance.state.selectedChannel).toBeNull();
@@ -49,7 +49,7 @@ test('チャンネル番組を選んで配信開始のための番組情報を�
   const selectedChannelId = 'ch9999';
   const selectedChannelName = 'チャンネルああああ'
   const programs = [{ id: 'lv1111' }, { id: 'lv2222' }];
-  instance.onSelectChannel(selectedChannelId, selectedChannelName, programs);
+  instance.onSelectChannel(selectedChannelId, selectedChannelName);
   expect(instance.state.currentStep).toBe('programSelect');
   // TODO: APIを叩くようになったら、モック化されたAPIを絡めたテストを書く
   // その際タイトルも検査するようにする
@@ -74,7 +74,7 @@ test('番組選択ステップで, チャンネルや番組の選択をしよう
   expect(instance.state.currentStep).toBe('providerTypeSelect');
 
   // チャンネル選択ができない
-  instance.onSelectChannel('ch1', 'name', []);
+  instance.onSelectChannel('ch1', 'name');
   expect(instance.state.currentStep).toBe('providerTypeSelect');
   expect(instance.state.selectedChannel).toBeNull();
 
@@ -101,7 +101,7 @@ test('チャンネル選択ステップで, 配信種別や番組の選択をし
   expect(instance.state.selectedProviderType).toBe('channel');
 
   // 配信種別をユーザー番組に変更できない
-  instance.onSelectProviderTypeUser('lv1');
+  instance.onSelectProviderTypeUser();
   expect(instance.state.currentStep).toBe('channelSelect');
   expect(instance.state.selectedProviderType).toBe('channel');
 
@@ -122,7 +122,7 @@ test('番組選択ステップで, 配信種別やチャンネルの選択をし
 
   // 番組選択へ
   const selectedChannelId = 'ch9999';
-  instance.onSelectChannel(selectedChannelId, 'チャンネルああああ', [{ id: 'lv1111' }, { id: 'lv2222' }]);
+  instance.onSelectChannel(selectedChannelId, 'チャンネルああああ');
   expect(instance.state.currentStep).toBe('programSelect');
 
   // 配信種別をチャンネルに変更しようとしても何も起きない
@@ -131,12 +131,12 @@ test('番組選択ステップで, 配信種別やチャンネルの選択をし
   expect(instance.state.selectedProviderType).toBe('channel');
 
   // 配信種別をユーザー番組に変更できない
-  instance.onSelectProviderTypeUser('lv1');
+  instance.onSelectProviderTypeUser();
   expect(instance.state.currentStep).toBe('programSelect');
   expect(instance.state.selectedProviderType).toBe('channel');
 
   // チャンネルを選択しようとしても何も起きない
-  instance.onSelectChannel('ch100000000', 'name', [])
+  instance.onSelectChannel('ch100000000', 'name')
   expect(instance.state.currentStep).toBe('programSelect');
   expect(instance.state.selectedChannel.id).toBe(selectedChannelId)
 });
@@ -148,7 +148,7 @@ test('ユーザー番組の確認ステップでは, あらゆる設定済の項
   expect(instance.state.currentStep).toBe('providerTypeSelect');
 
   // 確認へ
-  instance.onSelectProviderTypeUser('lv9800');
+  instance.onSelectProviderTypeUser();
   expect(instance.state.currentStep).toBe('confirm');
 
   // 配信種別をチャンネルに変更できない
@@ -162,7 +162,7 @@ test('ユーザー番組の確認ステップでは, あらゆる設定済の項
   expect(instance.state.selectedProviderType).toBe('user');
 
   // チャンネルを選択しようとしても何も起きない
-  instance.onSelectChannel('ch1111', 'name', [])
+  instance.onSelectChannel('ch1111', 'name')
   expect(instance.state.currentStep).toBe('confirm');
   expect(instance.state.selectedProviderType).toBe('user');
   expect(instance.state.selectedChannel).toBeNull();
@@ -184,7 +184,7 @@ test('チャンネル番組の確認ステップでは, あらゆる設定済の
 
   // 番組選択へ
   const selectedChannelId = 'ch9999';
-  instance.onSelectChannel(selectedChannelId, 'チャンネルああああ', [{ id: 'lv1111' }, { id: 'lv2222' }]);
+  instance.onSelectChannel(selectedChannelId, 'チャンネルああああ');
 
   // 確認へ
   const selectedProgram = 'lv1111';
@@ -202,7 +202,7 @@ test('チャンネル番組の確認ステップでは, あらゆる設定済の
   expect(instance.state.selectedProviderType).toBe('channel');
 
   // チャンネルを選択しようとしても変更できない
-  instance.onSelectChannel('ch1111', 'name', [])
+  instance.onSelectChannel('ch1111', 'name')
   expect(instance.state.currentStep).toBe('confirm');
   expect(instance.state.selectedProviderType).toBe('channel');
   expect(instance.state.selectedChannel.id).toBe(selectedChannelId);
@@ -226,7 +226,7 @@ describe('ステップ比較系メソッド', () => {
         case 'providerTypeSelect':
           return instance;
         case 'confirm':
-          instance.onSelectProviderTypeUser('id');
+          instance.onSelectProviderTypeUser();
           return instance;
         default:
           throw new Error('作れません')
@@ -240,11 +240,11 @@ describe('ステップ比較系メソッド', () => {
           return instance;
         case 'programSelect':
           instance.onSelectProviderTypeChannel();
-          instance.onSelectChannel('ch9999', 'name', [{ id: 'lv1' }, { id: 'lv2' }, { id: 'lv3' }]);
+          instance.onSelectChannel('ch9999', 'name');
           return instance;
         case 'confirm':
           instance.onSelectProviderTypeChannel();
-          instance.onSelectChannel('ch9999', 'name', [{ id: 'lv1' }, { id: 'lv2' }, { id: 'lv3' }]);
+          instance.onSelectChannel('ch9999', 'name');
           instance.onSelectBroadcastingProgram('id', 'title');
           return instance;
       }

--- a/app/services/nicolive-program/nicolive-program-selector.test.ts
+++ b/app/services/nicolive-program/nicolive-program-selector.test.ts
@@ -31,7 +31,7 @@ test('ユーザー番組を選んで配信開始のための番組情報を準�
   expect(instance.state.currentStep).toBe('confirm');
   expect(instance.state.selectedProviderType).toBe('user');
   expect(instance.state.selectedChannel).toBeNull();
-  expect(instance.state.selectedProgram).toMatchObject({ id: programId });
+  expect(instance.state.selectedChannelProgram).toMatchObject({ id: programId });
 });
 
 test('チャンネル番組を選んで配信開始のための番組情報を準備できる', () => {
@@ -64,7 +64,7 @@ test('チャンネル番組を選んで配信開始のための番組情報を�
   expect(instance.state.currentStep).toBe('confirm');
   expect(instance.state.selectedProviderType).toBe('channel');
   expect(instance.state.selectedChannel).toMatchObject({ id: selectedChannelId, name: selectedChannelName });
-  expect(instance.state.selectedProgram).toMatchObject({ id: selectedProgramId, title: selectedProgramTitle });
+  expect(instance.state.selectedChannelProgram).toMatchObject({ id: selectedProgramId, title: selectedProgramTitle });
 });
 
 test('番組選択ステップで, チャンネルや番組の選択をしようとしても何も起きない.', () => {
@@ -81,7 +81,7 @@ test('番組選択ステップで, チャンネルや番組の選択をしよう
   // 番組選択ができない
   instance.onSelectBroadcastingProgram('lv1', 'title')
   expect(instance.state.currentStep).toBe('providerTypeSelect');
-  expect(instance.state.selectedProgram).toBeNull();
+  expect(instance.state.selectedChannelProgram).toBeNull();
 });
 
 test('チャンネル選択ステップで, 配信種別や番組の選択をしようとしても何も起きない. ', () => {
@@ -108,7 +108,7 @@ test('チャンネル選択ステップで, 配信種別や番組の選択をし
   // 番組を選択できない
   instance.onSelectBroadcastingProgram('lv1', 'title')
   expect(instance.state.currentStep).toBe('channelSelect');
-  expect(instance.state.selectedProgram).toBeNull();
+  expect(instance.state.selectedChannelProgram).toBeNull();
 });
 
 test('番組選択ステップで, 配信種別やチャンネルの選択をしようとしても何も起きない.', () => {
@@ -171,7 +171,7 @@ test('ユーザー番組の確認ステップでは, あらゆる設定済の項
   instance.onSelectBroadcastingProgram('lv1111', 'title')
   expect(instance.state.currentStep).toBe('confirm');
   expect(instance.state.selectedProviderType).toBe('user');
-  expect(instance.state.selectedProgram.id).toBe('lv9800');
+  expect(instance.state.selectedChannelProgram.id).toBe('lv9800');
 });
 
 test('チャンネル番組の確認ステップでは, あらゆる設定済の項目を変更することはできない', () => {
@@ -212,7 +212,7 @@ test('チャンネル番組の確認ステップでは, あらゆる設定済の
   expect(instance.state.currentStep).toBe('confirm');
   console.log(instance.state.currentStep);
   expect(instance.state.selectedProviderType).toBe('channel');
-  expect(instance.state.selectedProgram.id).toBe(selectedProgram);
+  expect(instance.state.selectedChannelProgram.id).toBe(selectedProgram);
 });
 
 describe('ステップ比較系メソッド', () => {

--- a/app/services/nicolive-program/nicolive-program-selector.test.ts
+++ b/app/services/nicolive-program/nicolive-program-selector.test.ts
@@ -1,7 +1,7 @@
 import { createSetupFunction } from 'util/test-setup';
 import { Subject } from 'rxjs';
 import { NicoliveProgramSelectorService, TStep, TProviderType } from './nicolive-program-selector';
-import { OnairChannelsData, OnairChannelProgramData } from './ResponseTypes';
+import { OnairChannelData, OnairChannelProgramData } from './ResponseTypes';
 
 const setup = createSetupFunction({
   injectee: {
@@ -25,7 +25,7 @@ function createInstance() {
       thumbnailUrl: 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
       name: 'テスト用チャンネル2',
     }
-  ] as OnairChannelsData[]);
+  ] as OnairChannelData[]);
   instance.client.fetchOnairChannelProgram = jest.fn().mockResolvedValue({
     testProgramId: 'lv1111111111',
     programId: 'lv2222222222'

--- a/app/services/nicolive-program/nicolive-program-selector.test.ts
+++ b/app/services/nicolive-program/nicolive-program-selector.test.ts
@@ -1,6 +1,7 @@
 import { createSetupFunction } from 'util/test-setup';
 import { Subject } from 'rxjs';
 import { NicoliveProgramSelectorService, TStep, TProviderType } from './nicolive-program-selector';
+import { OnairChannelsData, OnairChannelProgramData } from './ResponseTypes';
 
 const setup = createSetupFunction({
   injectee: {
@@ -10,52 +11,83 @@ const setup = createSetupFunction({
   },
 });
 
+function createInstance() {
+  const { NicoliveProgramSelectorService } = require('./nicolive-program-selector');
+  const instance = NicoliveProgramSelectorService.instance as NicoliveProgramSelectorService;
+  instance.client.fetchOnairChannels = jest.fn().mockResolvedValue([
+    {
+      id: 'ch1',
+      thumbnailUrl: 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
+      name: 'テスト用チャンネル1',
+    },
+    {
+      id: 'ch2',
+      thumbnailUrl: 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
+      name: 'テスト用チャンネル2',
+    }
+  ] as OnairChannelsData[]);
+  instance.client.fetchOnairChannelProgram = jest.fn().mockResolvedValue({
+    testProgramId: 'lv1111111111',
+    programId: 'lv2222222222'
+  } as OnairChannelProgramData);
+  instance.client.fetchProgram = jest.fn().mockImplementation(
+    (programId: string) => Promise.resolve({
+      ok: true,
+      value: {
+        title: `これは ${programId} のタイトルです`
+      }
+    })
+  );
+  return instance;
+}
+
 beforeEach(() => {
   jest.doMock('services/stateful-service');
   jest.doMock('util/injector');
+  jest.mock('util/menus/Menu', () => ({}));
+  jest.mock('services/sources');
+  jest.mock('services/i18n', () => ({
+    $t: (x: any) => x,
+  }));
 });
 
 afterEach(() => {
   jest.resetModules();
 });
 
-test('ユーザー番組を選んで配信開始のための番組情報を準備できる', () => {
+test('ユーザー番組を選んで配信開始のための番組情報を準備できる', async () => {
   setup();
-  const { NicoliveProgramSelectorService } = require('./nicolive-program-selector');
-  const instance = NicoliveProgramSelectorService.instance as NicoliveProgramSelectorService;
+  const instance = createInstance();
   expect(instance.state.currentStep).toBe('providerTypeSelect');
 
   // 確認へ
-  const programId = 'lv1111';
-  instance.onSelectProviderTypeUser();
+  await instance.onSelectProviderType('user');
   expect(instance.state.currentStep).toBe('confirm');
   expect(instance.state.selectedProviderType).toBe('user');
   expect(instance.state.selectedChannel).toBeNull();
-  expect(instance.state.selectedChannelProgram).toMatchObject({ id: programId });
+  expect(instance.state.selectedChannelProgram).toBeNull();
 });
 
-test('チャンネル番組を選んで配信開始のための番組情報を準備できる', () => {
+test('チャンネル番組を選んで配信開始のための番組情報を準備できる', async () => {
   setup();
-  const { NicoliveProgramSelectorService } = require('./nicolive-program-selector');
-  const instance = NicoliveProgramSelectorService.instance as NicoliveProgramSelectorService;
+  const instance = createInstance();
   expect(instance.state.currentStep).toBe('providerTypeSelect');
 
   // チャンネル選択へ
-  instance.onSelectProviderTypeChannel();
+  await instance.onSelectProviderType('channel');
   expect(instance.state.currentStep).toBe('channelSelect');
   expect(instance.state.selectedProviderType).toBe('channel');
 
   // 番組選択へ
   const selectedChannelId = 'ch9999';
   const selectedChannelName = 'チャンネルああああ'
-  const programs = [{ id: 'lv1111' }, { id: 'lv2222' }];
-  instance.onSelectChannel(selectedChannelId, selectedChannelName);
+  await instance.onSelectChannel(selectedChannelId, selectedChannelName);
   expect(instance.state.currentStep).toBe('programSelect');
-  // TODO: APIを叩くようになったら、モック化されたAPIを絡めたテストを書く
-  // その際タイトルも検査するようにする
   expect(instance.state.selectedChannel).toMatchObject({ id: selectedChannelId, name: selectedChannelName })
-  expect(instance.state.candidatePrograms[0].id).toBe(programs[0].id);
-  expect(instance.state.candidatePrograms[1].id).toBe(programs[1].id);
+  expect(instance.state.candidatePrograms[0].id).toBe('lv1111111111');
+  expect(instance.state.candidatePrograms[0].title).toBe('これは lv1111111111 のタイトルです');
+  expect(instance.state.candidatePrograms[1].id).toBe('lv2222222222');
+  expect(instance.state.candidatePrograms[1].title).toBe('これは lv2222222222 のタイトルです');
 
   // 確認へ
   const selectedProgramId = 'lv1111';
@@ -67,14 +99,13 @@ test('チャンネル番組を選んで配信開始のための番組情報を�
   expect(instance.state.selectedChannelProgram).toMatchObject({ id: selectedProgramId, title: selectedProgramTitle });
 });
 
-test('番組選択ステップで, チャンネルや番組の選択をしようとしても何も起きない.', () => {
+test('番組選択ステップで, チャンネルや番組の選択をしようとしても何も起きない.', async () => {
   setup();
-  const { NicoliveProgramSelectorService } = require('./nicolive-program-selector');
-  const instance = NicoliveProgramSelectorService.instance as NicoliveProgramSelectorService;
+  const instance = createInstance();
   expect(instance.state.currentStep).toBe('providerTypeSelect');
 
   // チャンネル選択ができない
-  instance.onSelectChannel('ch1', 'name');
+  await instance.onSelectChannel('ch1', 'name');
   expect(instance.state.currentStep).toBe('providerTypeSelect');
   expect(instance.state.selectedChannel).toBeNull();
 
@@ -84,24 +115,23 @@ test('番組選択ステップで, チャンネルや番組の選択をしよう
   expect(instance.state.selectedChannelProgram).toBeNull();
 });
 
-test('チャンネル選択ステップで, 配信種別や番組の選択をしようとしても何も起きない. ', () => {
+test('チャンネル選択ステップで, 配信種別や番組の選択をしようとしても何も起きない. ', async () => {
   setup();
-  const { NicoliveProgramSelectorService } = require('./nicolive-program-selector');
-  const instance = NicoliveProgramSelectorService.instance as NicoliveProgramSelectorService;
+  const instance = createInstance();
   expect(instance.state.currentStep).toBe('providerTypeSelect');
 
   // チャンネル選択へ
-  instance.onSelectProviderTypeChannel();
+  await instance.onSelectProviderType('channel');
   expect(instance.state.currentStep).toBe('channelSelect');
   expect(instance.state.selectedProviderType).toBe('channel');
 
   // 配信種別をチャンネルに変更しようとしても何も起きない
-  instance.onSelectProviderTypeChannel();
+  await instance.onSelectProviderType('channel');
   expect(instance.state.currentStep).toBe('channelSelect');
   expect(instance.state.selectedProviderType).toBe('channel');
 
   // 配信種別をユーザー番組に変更できない
-  instance.onSelectProviderTypeUser();
+  await instance.onSelectProviderType('channel');
   expect(instance.state.currentStep).toBe('channelSelect');
   expect(instance.state.selectedProviderType).toBe('channel');
 
@@ -111,27 +141,26 @@ test('チャンネル選択ステップで, 配信種別や番組の選択をし
   expect(instance.state.selectedChannelProgram).toBeNull();
 });
 
-test('番組選択ステップで, 配信種別やチャンネルの選択をしようとしても何も起きない.', () => {
+test('番組選択ステップで, 配信種別やチャンネルの選択をしようとしても何も起きない.', async () => {
   setup();
-  const { NicoliveProgramSelectorService } = require('./nicolive-program-selector');
-  const instance = NicoliveProgramSelectorService.instance as NicoliveProgramSelectorService;
+  const instance = createInstance();
   expect(instance.state.currentStep).toBe('providerTypeSelect');
 
   // チャンネル選択へ
-  instance.onSelectProviderTypeChannel();
+  await instance.onSelectProviderType('channel');
 
   // 番組選択へ
   const selectedChannelId = 'ch9999';
-  instance.onSelectChannel(selectedChannelId, 'チャンネルああああ');
+  await instance.onSelectChannel(selectedChannelId, 'チャンネルああああ');
   expect(instance.state.currentStep).toBe('programSelect');
 
   // 配信種別をチャンネルに変更しようとしても何も起きない
-  instance.onSelectProviderTypeChannel();
+  await instance.onSelectProviderType('channel');
   expect(instance.state.currentStep).toBe('programSelect');
   expect(instance.state.selectedProviderType).toBe('channel');
 
   // 配信種別をユーザー番組に変更できない
-  instance.onSelectProviderTypeUser();
+  await instance.onSelectProviderType('user');
   expect(instance.state.currentStep).toBe('programSelect');
   expect(instance.state.selectedProviderType).toBe('channel');
 
@@ -141,28 +170,27 @@ test('番組選択ステップで, 配信種別やチャンネルの選択をし
   expect(instance.state.selectedChannel.id).toBe(selectedChannelId)
 });
 
-test('ユーザー番組の確認ステップでは, あらゆる設定済の項目を変更することはできない.', () => {
+test('ユーザー番組の確認ステップでは, あらゆる設定済の項目を変更することはできない.', async () => {
   setup();
-  const { NicoliveProgramSelectorService } = require('./nicolive-program-selector');
-  const instance = NicoliveProgramSelectorService.instance as NicoliveProgramSelectorService;
+  const instance = createInstance();
   expect(instance.state.currentStep).toBe('providerTypeSelect');
 
   // 確認へ
-  instance.onSelectProviderTypeUser();
+  await instance.onSelectProviderType('user');
   expect(instance.state.currentStep).toBe('confirm');
 
   // 配信種別をチャンネルに変更できない
-  instance.onSelectProviderTypeChannel();
+  await instance.onSelectProviderType('channel');
   expect(instance.state.currentStep).toBe('confirm');
   expect(instance.state.selectedProviderType).toBe('user');
 
   // 配信種別をユーザーに変更しようとしても何も起きない
-  instance.onSelectProviderTypeChannel();
+  await instance.onSelectProviderType('channel');
   expect(instance.state.currentStep).toBe('confirm');
   expect(instance.state.selectedProviderType).toBe('user');
 
   // チャンネルを選択しようとしても何も起きない
-  instance.onSelectChannel('ch1111', 'name')
+  await instance.onSelectChannel('ch1111', 'name')
   expect(instance.state.currentStep).toBe('confirm');
   expect(instance.state.selectedProviderType).toBe('user');
   expect(instance.state.selectedChannel).toBeNull();
@@ -171,20 +199,19 @@ test('ユーザー番組の確認ステップでは, あらゆる設定済の項
   instance.onSelectBroadcastingProgram('lv1111', 'title')
   expect(instance.state.currentStep).toBe('confirm');
   expect(instance.state.selectedProviderType).toBe('user');
-  expect(instance.state.selectedChannelProgram.id).toBe('lv9800');
+  expect(instance.state.selectedChannel).toBeNull();
 });
 
-test('チャンネル番組の確認ステップでは, あらゆる設定済の項目を変更することはできない', () => {
+test('チャンネル番組の確認ステップでは, あらゆる設定済の項目を変更することはできない', async () => {
   setup();
-  const { NicoliveProgramSelectorService } = require('./nicolive-program-selector');
-  const instance = NicoliveProgramSelectorService.instance as NicoliveProgramSelectorService;
+  const instance = createInstance();
   expect(instance.state.currentStep).toBe('providerTypeSelect');
   // チャンネル選択へ
-  instance.onSelectProviderTypeChannel();
+  await instance.onSelectProviderType('channel');
 
   // 番組選択へ
   const selectedChannelId = 'ch9999';
-  instance.onSelectChannel(selectedChannelId, 'チャンネルああああ');
+  await instance.onSelectChannel(selectedChannelId, 'チャンネルああああ');
 
   // 確認へ
   const selectedProgram = 'lv1111';
@@ -192,17 +219,17 @@ test('チャンネル番組の確認ステップでは, あらゆる設定済の
   expect(instance.state.currentStep).toBe('confirm');
 
   // 配信種別をチャンネルに変更しようとしても何も起きない
-  instance.onSelectProviderTypeChannel();
+  await instance.onSelectProviderType('channel');
   expect(instance.state.currentStep).toBe('confirm');
   expect(instance.state.selectedProviderType).toBe('channel');
 
   // 配信種別をユーザーに変更できない
-  instance.onSelectProviderTypeChannel();
+  await instance.onSelectProviderType('channel');
   expect(instance.state.currentStep).toBe('confirm');
   expect(instance.state.selectedProviderType).toBe('channel');
 
   // チャンネルを選択しようとしても変更できない
-  instance.onSelectChannel('ch1111', 'name')
+  await instance.onSelectChannel('ch1111', 'name')
   expect(instance.state.currentStep).toBe('confirm');
   expect(instance.state.selectedProviderType).toBe('channel');
   expect(instance.state.selectedChannel.id).toBe(selectedChannelId);
@@ -210,23 +237,21 @@ test('チャンネル番組の確認ステップでは, あらゆる設定済の
   // 番組を選択しようとしても変更できない
   instance.onSelectBroadcastingProgram('lv2222', 'title')
   expect(instance.state.currentStep).toBe('confirm');
-  console.log(instance.state.currentStep);
   expect(instance.state.selectedProviderType).toBe('channel');
   expect(instance.state.selectedChannelProgram.id).toBe(selectedProgram);
 });
 
 describe('ステップ比較系メソッド', () => {
   // 指定ステップの状態のインスタンスを作るユーティリティ
-  function createServiceInstanceByStep(step: TStep, providerType: TProviderType) {
+  async function createServiceInstanceByStep(step: TStep, providerType: TProviderType) {
     setup();
-    const { NicoliveProgramSelectorService } = require('./nicolive-program-selector');
-    const instance = NicoliveProgramSelectorService.instance as NicoliveProgramSelectorService;
+    const instance = createInstance();
     if (providerType === 'user') {
       switch (step) {
         case 'providerTypeSelect':
           return instance;
         case 'confirm':
-          instance.onSelectProviderTypeUser();
+          await instance.onSelectProviderType('user');
           return instance;
         default:
           throw new Error('作れません')
@@ -236,89 +261,89 @@ describe('ステップ比較系メソッド', () => {
         case 'providerTypeSelect':
           return instance;
         case 'channelSelect':
-          instance.onSelectProviderTypeChannel();
+          await instance.onSelectProviderType('channel');
           return instance;
         case 'programSelect':
-          instance.onSelectProviderTypeChannel();
-          instance.onSelectChannel('ch9999', 'name');
+          await instance.onSelectProviderType('channel');
+          await instance.onSelectChannel('ch9999', 'name');
           return instance;
         case 'confirm':
-          instance.onSelectProviderTypeChannel();
-          instance.onSelectChannel('ch9999', 'name');
+          await instance.onSelectProviderType('channel');
+          await instance.onSelectChannel('ch9999', 'name');
           instance.onSelectBroadcastingProgram('id', 'title');
           return instance;
       }
     }
   }
   describe('isCompletedOrCurrentStep', () => {
-    test('providerTypeSelect ステップのインスタンスに対して正しい値を返す', () => {
+    test('providerTypeSelect ステップのインスタンスに対して正しい値を返す', async () => {
       // 初期状態なので, 'user' でも同様.
-      const instance = createServiceInstanceByStep('providerTypeSelect', 'channel');
+      const instance = await createServiceInstanceByStep('providerTypeSelect', 'channel');
       expect(instance.isCompletedOrCurrentStep('providerTypeSelect')).toBe(true);
       expect(instance.isCompletedOrCurrentStep('channelSelect')).toBe(false);
       expect(instance.isCompletedOrCurrentStep('programSelect')).toBe(false);
       expect(instance.isCompletedOrCurrentStep('confirm')).toBe(false);
     });
-    test('channelSelect ステップのインスタンスに対して正しい値を返す', () => {
-      const instance = createServiceInstanceByStep('channelSelect', 'channel');
+    test('channelSelect ステップのインスタンスに対して正しい値を返す', async () => {
+      const instance = await createServiceInstanceByStep('channelSelect', 'channel');
       expect(instance.isCompletedOrCurrentStep('providerTypeSelect')).toBe(true);
       expect(instance.isCompletedOrCurrentStep('channelSelect')).toBe(true);
       expect(instance.isCompletedOrCurrentStep('programSelect')).toBe(false);
       expect(instance.isCompletedOrCurrentStep('confirm')).toBe(false);
     });
-    test('programSelect ステップのインスタンスに対して正しい値を返す', () => {
-      const instance = createServiceInstanceByStep('programSelect', 'channel');
+    test('programSelect ステップのインスタンスに対して正しい値を返す', async () => {
+      const instance = await createServiceInstanceByStep('programSelect', 'channel');
       expect(instance.isCompletedOrCurrentStep('providerTypeSelect')).toBe(true);
       expect(instance.isCompletedOrCurrentStep('channelSelect')).toBe(true);
       expect(instance.isCompletedOrCurrentStep('programSelect')).toBe(true);
       expect(instance.isCompletedOrCurrentStep('confirm')).toBe(false);
     });
-    test('confirm ステップ (チャンネル番組) のインスタンスに対して正しい値を返す', () => {
-      const instance = createServiceInstanceByStep('confirm', 'channel');
+    test('confirm ステップ (チャンネル番組) のインスタンスに対して正しい値を返す', async () => {
+      const instance = await createServiceInstanceByStep('confirm', 'channel');
       expect(instance.isCompletedOrCurrentStep('providerTypeSelect')).toBe(true);
       expect(instance.isCompletedOrCurrentStep('channelSelect')).toBe(true);
       expect(instance.isCompletedOrCurrentStep('programSelect')).toBe(true);
       expect(instance.isCompletedOrCurrentStep('confirm')).toBe(true);
     });
-    test('confirm ステップ (ユーザー番組) のインスタンスに対して正しい値を返す', () => {
-      const instance = createServiceInstanceByStep('confirm', 'user');
+    test('confirm ステップ (ユーザー番組) のインスタンスに対して正しい値を返す', async () => {
+      const instance = await createServiceInstanceByStep('confirm', 'user');
       expect(instance.isCompletedOrCurrentStep('providerTypeSelect')).toBe(true);
       expect(instance.isCompletedOrCurrentStep('channelSelect')).toBe(false); // ユーザー番組は経由しない
       expect(instance.isCompletedOrCurrentStep('programSelect')).toBe(false); // ユーザー番組は経由しない
     });
   });
   describe('isCompletedStep', () => {
-    test('providerTypeSelect ステップのインスタンスに対して正しい値を返す', () => {
+    test('providerTypeSelect ステップのインスタンスに対して正しい値を返す', async () => {
       // 初期状態なので, 'user' でも同様.
-      const instance = createServiceInstanceByStep('providerTypeSelect', 'channel');
+      const instance = await createServiceInstanceByStep('providerTypeSelect', 'channel');
       expect(instance.isCompletedStep('providerTypeSelect')).toBe(false);
       expect(instance.isCompletedStep('channelSelect')).toBe(false);
       expect(instance.isCompletedStep('programSelect')).toBe(false);
       expect(instance.isCompletedStep('confirm')).toBe(false);
     });
-    test('channelSelect ステップのインスタンスに対して正しい値を返す', () => {
-      const instance = createServiceInstanceByStep('channelSelect', 'channel');
+    test('channelSelect ステップのインスタンスに対して正しい値を返す', async () => {
+      const instance = await createServiceInstanceByStep('channelSelect', 'channel');
       expect(instance.isCompletedStep('providerTypeSelect')).toBe(true);
       expect(instance.isCompletedStep('channelSelect')).toBe(false);
       expect(instance.isCompletedStep('programSelect')).toBe(false);
       expect(instance.isCompletedStep('confirm')).toBe(false);
     });
-    test('programSelect ステップのインスタンスに対して正しい値を返す', () => {
-      const instance = createServiceInstanceByStep('programSelect', 'channel');
+    test('programSelect ステップのインスタンスに対して正しい値を返す', async () => {
+      const instance = await createServiceInstanceByStep('programSelect', 'channel');
       expect(instance.isCompletedStep('providerTypeSelect')).toBe(true);
       expect(instance.isCompletedStep('channelSelect')).toBe(true);
       expect(instance.isCompletedStep('programSelect')).toBe(false);
       expect(instance.isCompletedStep('confirm')).toBe(false);
     });
-    test('confirm ステップ (チャンネル番組) のインスタンスに対して正しい値を返す', () => {
-      const instance = createServiceInstanceByStep('confirm', 'channel');
+    test('confirm ステップ (チャンネル番組) のインスタンスに対して正しい値を返す', async () => {
+      const instance = await createServiceInstanceByStep('confirm', 'channel');
       expect(instance.isCompletedStep('providerTypeSelect')).toBe(true);
       expect(instance.isCompletedStep('channelSelect')).toBe(true);
       expect(instance.isCompletedStep('programSelect')).toBe(true);
       expect(instance.isCompletedStep('confirm')).toBe(false);
     });
-    test('confirm ステップ (ユーザー番組) のインスタンスに対して正しい値を返す', () => {
-      const instance = createServiceInstanceByStep('confirm', 'user');
+    test('confirm ステップ (ユーザー番組) のインスタンスに対して正しい値を返す', async () => {
+      const instance = await createServiceInstanceByStep('confirm', 'user');
       expect(instance.isCompletedStep('providerTypeSelect')).toBe(true);
       expect(instance.isCompletedStep('channelSelect')).toBe(false); // ユーザー番組は経由しない
       expect(instance.isCompletedStep('programSelect')).toBe(false); // ユーザー番組は経由しない
@@ -326,9 +351,21 @@ describe('ステップ比較系メソッド', () => {
     });
   });
   describe('backTo', () => {
+    const expectedChannels = [
+      {
+        id: 'ch1',
+        name: 'テスト用チャンネル1',
+        thumbnailUrl: 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
+      },
+      {
+        id: 'ch2',
+        name: 'テスト用チャンネル2',
+        thumbnailUrl: 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
+      },
+    ];
     describe('providerTypeSelect ステップのインスタンスに対して呼び出しても何も起こらない', () => {
-      test('どの状態に戻ろうとしても何も起こらない', () => {
-        const instance = createServiceInstanceByStep('providerTypeSelect', 'channel');
+      test('どの状態に戻ろうとしても何も起こらない', async () => {
+        const instance = await createServiceInstanceByStep('providerTypeSelect', 'channel');
         (instance as any).SET_STATE = jest.fn();
         instance.backTo('providerTypeSelect');
         instance.backTo('channelSelect');
@@ -338,19 +375,20 @@ describe('ステップ比較系メソッド', () => {
       })
     });
     describe('broadcastChanelSelect ステップのインスタンスに対して状態をクリアできる', () => {
-      test('providerTypeSelect ステップに戻るときに適切な状態に初期化できる', () => {
-        const instance = createServiceInstanceByStep('channelSelect', 'channel');
+      test('providerTypeSelect ステップに戻るときに適切な状態に初期化できる', async () => {
+        const instance = await createServiceInstanceByStep('channelSelect', 'channel');
         instance.backTo('providerTypeSelect');
         expect(instance.state).toMatchObject({
           currentStep: 'providerTypeSelect',
+          candidateChannels: [],
           candidatePrograms: [],
           selectedProviderType: null,
           selectedChannel: null,
-          selectedProgram: null
+          selectedChannelProgram: null
         });
       });
-      test('その他のステップに戻ろうとしても何も起こらない', () => {
-        const instance = createServiceInstanceByStep('channelSelect', 'channel');
+      test('その他のステップに戻ろうとしても何も起こらない', async () => {
+        const instance = await createServiceInstanceByStep('channelSelect', 'channel');
         (instance as any).SET_STATE = jest.fn();
         instance.backTo('channelSelect');
         instance.backTo('programSelect');
@@ -359,30 +397,32 @@ describe('ステップ比較系メソッド', () => {
       })
     });
     describe('programSelect ステップのインスタンスに対して状態をクリアできる', () => {
-      test('providerTypeSelect ステップに戻るときに適切な状態に初期化できる', () => {
-        const instance = createServiceInstanceByStep('programSelect', 'channel');
+      test('providerTypeSelect ステップに戻るときに適切な状態に初期化できる', async () => {
+        const instance = await createServiceInstanceByStep('programSelect', 'channel');
         instance.backTo('providerTypeSelect');
         expect(instance!.state).toMatchObject({
           currentStep: 'providerTypeSelect',
+          candidateChannels: [],
           candidatePrograms: [],
           selectedProviderType: null,
           selectedChannel: null,
-          selectedProgram: null
+          selectedChannelProgram: null
         });
       });
-      test('channelSelect ステップに戻るときに適切な状態に初期化できる', () => {
-        const instance = createServiceInstanceByStep('programSelect', 'channel');
+      test('channelSelect ステップに戻るときに適切な状態に初期化できる', async () => {
+        const instance = await createServiceInstanceByStep('programSelect', 'channel');
         instance.backTo('channelSelect');
         expect(instance.state).toMatchObject({
           currentStep: 'channelSelect',
+          candidateChannels: expectedChannels,
           candidatePrograms: [],
           selectedProviderType: 'channel',
           selectedChannel: null,
-          selectedProgram: null
+          selectedChannelProgram: null
         });
       });
-      test('その他のステップに戻ろうとしても何も起こらない', () => {
-        const instance = createServiceInstanceByStep('programSelect', 'channel');
+      test('その他のステップに戻ろうとしても何も起こらない', async () => {
+        const instance = await createServiceInstanceByStep('programSelect', 'channel');
         (instance as any).SET_STATE = jest.fn();
         instance.backTo('programSelect');
         instance.backTo('confirm');
@@ -390,65 +430,67 @@ describe('ステップ比較系メソッド', () => {
       });
     });
     describe('confirm ステップ (チャンネル番組) のインスタンスに対して状態をクリアできる', () => {
-      test('providerTypeSelect ステップに戻るときに適切な状態に初期化できる', () => {
-        const instance = createServiceInstanceByStep('confirm', 'channel');
+      test('providerTypeSelect ステップに戻るときに適切な状態に初期化できる', async () => {
+        const instance = await createServiceInstanceByStep('confirm', 'channel');
         instance.backTo('providerTypeSelect');
         expect(instance.state).toMatchObject({
           currentStep: 'providerTypeSelect',
+          candidateChannels: [],
           candidatePrograms: [],
           selectedProviderType: null,
           selectedChannel: null,
-          selectedProgram: null
+          selectedChannelProgram: null
         });
       });
-      test('channelSelect ステップに戻るときに適切な状態に初期化できる', () => {
-        const instance = createServiceInstanceByStep('confirm', 'channel');
+      test('channelSelect ステップに戻るときに適切な状態に初期化できる', async () => {
+        const instance = await createServiceInstanceByStep('confirm', 'channel');
         instance.backTo('channelSelect');
         expect(instance.state).toMatchObject({
           currentStep: 'channelSelect',
+          candidateChannels: expectedChannels,
           candidatePrograms: [],
           selectedProviderType: 'channel',
           selectedChannel: null,
-          selectedProgram: null
+          selectedChannelProgram: null
         });
       });
-      test('programSelect ステップに戻るときに適切な状態に初期化できる', () => {
-        const instance = createServiceInstanceByStep('confirm', 'channel');
+      test('programSelect ステップに戻るときに適切な状態に初期化できる', async () => {
+        const instance = await createServiceInstanceByStep('confirm', 'channel');
         instance.backTo('programSelect');
         expect(instance.state).toMatchObject({
           currentStep: 'programSelect',
+          candidateChannels: expectedChannels,
           candidatePrograms: [
-            // TODO: 番組情報取得APIを叩くようになったらそのAPIのモックの値に変更する必要がある
-            { id: 'lv1', title: 'これは lv1 のタイトルです' },
-            { id: 'lv2', title: 'これは lv2 のタイトルです' },
-            { id: 'lv3', title: 'これは lv3 のタイトルです' }
+            { id: 'lv1111111111', title: 'これは lv1111111111 のタイトルです' },
+            { id: 'lv2222222222', title: 'これは lv2222222222 のタイトルです' },
           ],
           selectedProviderType: 'channel',
           selectedChannel: { id: 'ch9999', name: 'name' },
-          selectedProgram: null
+          selectedChannelProgram: null
         });
       });
-      test('confirm ステップに戻ろうとしても何も起こらない', () => {
-        const instance = createServiceInstanceByStep('confirm', 'channel');
+      test('confirm ステップに戻ろうとしても何も起こらない', async () => {
+        const instance = await createServiceInstanceByStep('confirm', 'channel');
         (instance as any).SET_STATE = jest.fn();
         instance.backTo('confirm');
         expect((instance as any).SET_STATE).not.toBeCalled();
       });
     });
     describe('confirm ステップ (ユーザー番組) のインスタンスに対して状態をクリアできる', () => {
-      test('providerTypeSelect ステップに戻るときに適切な状態に初期化できる', () => {
-        const instance = createServiceInstanceByStep('confirm', 'user');
+      test('providerTypeSelect ステップに戻るときに適切な状態に初期化できる', async () => {
+        const instance = await createServiceInstanceByStep('confirm', 'user');
         instance.backTo('providerTypeSelect');
         expect(instance.state).toMatchObject({
           currentStep: 'providerTypeSelect',
+          candidateChannels: [],
           candidatePrograms: [],
           selectedProviderType: null,
           selectedChannel: null,
-          selectedProgram: null
+          selectedChannelProgram: null
         });
       });
-      test('他のステップに戻ろうとしても何も起こらない', () => {
-        const instance = createServiceInstanceByStep('confirm', 'user');
+      test('他のステップに戻ろうとしても何も起こらない', async () => {
+        const instance = await createServiceInstanceByStep('confirm', 'user');
         (instance as any).SET_STATE = jest.fn();
         instance.backTo('channelSelect'); // ユーザー番組ではスキップされるため無効
         instance.backTo('programSelect');  // ユーザー番組ではスキップされるため無効

--- a/app/services/nicolive-program/nicolive-program-selector.ts
+++ b/app/services/nicolive-program/nicolive-program-selector.ts
@@ -76,11 +76,19 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
         selectedProviderType: 'channel',
         isLoading: true
       });
-      const candidateChannels = await this.client.fetchOnairChannels();
-      this.SET_STATE({
-        isLoading: false,
-        candidateChannels
-      });
+      try {
+        const candidateChannels = await this.client.fetchOnairChannels();
+        this.SET_STATE({
+          isLoading: false,
+          candidateChannels
+        });
+      } catch (error) {
+        // 番組選択ウィンドウを出した後、メインウィンドウでログアウトした場合にここに到達することがある
+        // TODO: 何らかのエラー表示を出すか、エラー時の挙動を決める
+        this.SET_STATE({
+          isLoading: false
+        })
+      }
     } else { // providerType === 'user'
       this.SET_STATE({
         selectedProviderType: 'user',

--- a/app/services/nicolive-program/nicolive-program-selector.ts
+++ b/app/services/nicolive-program/nicolive-program-selector.ts
@@ -41,7 +41,7 @@ const stepsMap = steps.reduce<{ [key in TStep]?: number }>((prev, current, index
 export interface INicoliveProgramSelectorState {
   selectedProviderType: TProviderType | null;
   selectedChannel: { id: string; name: string } | null;
-  selectedProgram: { id: string; title?: string } | null; // ユーザー番組の場合はタイトルは取得せず undefined のまま
+  selectedChannelProgram: { id: string; title: string } | null; // ユーザー生放送時 null
   candidateChannels: OnairChannelsData[];
   candidatePrograms: { id: string; title: string }[];
   isLoading: boolean;
@@ -53,7 +53,7 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
   static initialState: INicoliveProgramSelectorState = {
     selectedProviderType: null,
     selectedChannel: null,
-    selectedProgram:  null,
+    selectedChannelProgram:  null,
     candidateChannels: [],
     candidatePrograms: [],
     isLoading: false,
@@ -89,7 +89,6 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
     this.SET_STATE({
       selectedProviderType: 'user',
       selectedChannel: null,
-      selectedProgram: { id: 'hoge' }, // TODO
       currentStep: 'confirm'
     });
   }
@@ -131,7 +130,7 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
       return;
     }
     this.SET_STATE({
-      selectedProgram: { id, title },
+      selectedChannelProgram: { id, title },
       currentStep: 'confirm'
     });
   }
@@ -174,7 +173,7 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
       candidatePrograms: stepsMap[step] <= stepsMap['channelSelect'] ? [] : this.state.candidatePrograms,
       selectedProviderType: stepsMap[step] <= stepsMap['providerTypeSelect'] ? null : this.state.selectedProviderType,
       selectedChannel: stepsMap[step] <= stepsMap['channelSelect'] ? null : this.state.selectedChannel,
-      selectedProgram: stepsMap[step] <= stepsMap['programSelect']  ? null : this.state.selectedProgram,
+      selectedChannelProgram: stepsMap[step] <= stepsMap['programSelect']  ? null : this.state.selectedChannelProgram,
     });
   }
 

--- a/app/services/nicolive-program/nicolive-program-selector.ts
+++ b/app/services/nicolive-program/nicolive-program-selector.ts
@@ -53,7 +53,7 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
   static initialState: INicoliveProgramSelectorState = {
     selectedProviderType: null,
     selectedChannel: null,
-    selectedChannelProgram:  null,
+    selectedChannelProgram: null,
     candidateChannels: [],
     candidatePrograms: [],
     isLoading: false,
@@ -66,31 +66,28 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
     super.init();
   }
 
-  async onSelectProviderTypeChannel() {
+  async onSelectProviderType(providerType: TProviderType) {
     if (this.state.currentStep !== 'providerTypeSelect') {
       return;
     }
-    this.SET_STATE({
-      currentStep: 'channelSelect',
-      selectedProviderType: 'channel',
-      isLoading: true
-    });
-    const candidateChannels = await this.client.fetchOnairChannels();
-    this.SET_STATE({
-      isLoading: false,
-      candidateChannels
-    });
-  }
-
-  onSelectProviderTypeUser() {
-    if (this.state.currentStep !== 'providerTypeSelect') {
-      return;
+    if (providerType === 'channel') {
+      this.SET_STATE({
+        currentStep: 'channelSelect',
+        selectedProviderType: 'channel',
+        isLoading: true
+      });
+      const candidateChannels = await this.client.fetchOnairChannels();
+      this.SET_STATE({
+        isLoading: false,
+        candidateChannels
+      });
+    } else { // providerType === 'user'
+      this.SET_STATE({
+        selectedProviderType: 'user',
+        selectedChannel: null,
+        currentStep: 'confirm'
+      });
     }
-    this.SET_STATE({
-      selectedProviderType: 'user',
-      selectedChannel: null,
-      currentStep: 'confirm'
-    });
   }
 
   /**
@@ -100,7 +97,7 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
    * @param name 配信するチャンネル名
    */
   async onSelectChannel(id: string, name: string) {
-    if(this.state.currentStep !== 'channelSelect') {
+    if (this.state.currentStep !== 'channelSelect') {
       return;
     }
     this.SET_STATE({
@@ -115,7 +112,7 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
       try {
         const program = await this.client.fetchProgram(programId);
         return program.ok ? { id: programId, title: program.value.title } : undefined;
-      } catch(error) {
+      } catch (error) {
         return undefined;
       }
     }))).filter(Boolean);
@@ -126,7 +123,7 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
   }
 
   onSelectBroadcastingProgram(id: string, title: string) {
-    if(this.state.currentStep !== 'programSelect') {
+    if (this.state.currentStep !== 'programSelect') {
       return;
     }
     this.SET_STATE({
@@ -173,7 +170,7 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
       candidatePrograms: stepsMap[step] <= stepsMap['channelSelect'] ? [] : this.state.candidatePrograms,
       selectedProviderType: stepsMap[step] <= stepsMap['providerTypeSelect'] ? null : this.state.selectedProviderType,
       selectedChannel: stepsMap[step] <= stepsMap['channelSelect'] ? null : this.state.selectedChannel,
-      selectedChannelProgram: stepsMap[step] <= stepsMap['programSelect']  ? null : this.state.selectedChannelProgram,
+      selectedChannelProgram: stepsMap[step] <= stepsMap['programSelect'] ? null : this.state.selectedChannelProgram,
     });
   }
 

--- a/app/services/nicolive-program/nicolive-program-selector.ts
+++ b/app/services/nicolive-program/nicolive-program-selector.ts
@@ -42,7 +42,7 @@ export interface INicoliveProgramSelectorState {
   selectedProviderType: TProviderType | null;
   selectedChannel: { id: string; name: string } | null;
   selectedProgram: { id: string; title?: string } | null; // ユーザー番組の場合はタイトルは取得せず undefined のまま
-  candidateChannels: OnairChannelsData;
+  candidateChannels: OnairChannelsData[];
   candidatePrograms: { id: string; title: string }[];
   isLoading: boolean;
   currentStep: TStep;
@@ -75,7 +75,7 @@ export class NicoliveProgramSelectorService extends StatefulService<INicolivePro
       selectedProviderType: 'channel',
       isLoading: true
     });
-    const candidateChannels = await this.client.fetchOnairChannnels();
+    const candidateChannels = await this.client.fetchOnairChannels();
     this.SET_STATE({
       isLoading: false,
       candidateChannels

--- a/app/services/nicolive-program/nicolive-program-selector.ts
+++ b/app/services/nicolive-program/nicolive-program-selector.ts
@@ -1,6 +1,6 @@
 import { StatefulService, mutation } from 'services/stateful-service';
 import { NicoliveClient } from './NicoliveClient';
-import { OnairChannelsData } from './ResponseTypes';
+import { OnairChannelData } from './ResponseTypes';
 
 /**
  * 配信する番組種別
@@ -42,7 +42,7 @@ export interface INicoliveProgramSelectorState {
   selectedProviderType: TProviderType | null;
   selectedChannel: { id: string; name: string } | null;
   selectedChannelProgram: { id: string; title: string } | null; // ユーザー生放送時 null
-  candidateChannels: OnairChannelsData[];
+  candidateChannels: OnairChannelData[];
   candidatePrograms: { id: string; title: string }[];
   isLoading: boolean;
   currentStep: TStep;

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -120,7 +120,18 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
     });
   }
 
-  // 配信開始ボタンまたはショートカットキーによる配信開始(対話可能)
+  /**
+   * 配信開始ボタンまたはショートカットキーによる配信開始(対話可能)
+   * 
+   * 現在ログインされているユーザーで、配信可能なチャンネルが存在する場合には、配信番組選択ウィンドウを開きます。
+   * 
+   * 配信番組選択ウィンドウで「配信開始」ボタンを押した時にもこのメソッドが呼ばれ、
+   * options.nicoliveProgramSelectorResult に、ウィンドウで選ばれた配信種別と
+   * チャンネル番組の場合は番組IDが与えられます。
+   * 
+   * 配信番組選択ウィンドウからの呼び出しの場合、および現在ログインされているユーザーで
+   * 配信可能なチャンネルが存在しない場合には、配信開始を試みます。
+   */
   async toggleStreamingAsync(
     options: {
       nicoliveProgramSelectorResult?: {


### PR DESCRIPTION
# このpull requestが解決する内容
番組選択ウィンドウで、実際にチャンネルおよび配信する番組を決定して配信を開始できるようにする。

**※異常系の対応は、このPRでは配信可能なチャンネル番組が0件の場合のみです。 APIのエラー時の挙動は、最低限操作不能にならないようにする程度となっていますが、追って別PRで対応の予定です。**

# 動作確認手順
- [x] `yarn test:unit`
- [x] チャンネルが紐ついていないユーザーで、ユーザー生放送が作成されていないとき、配信開始しようとするとダイアログが出ること
- [x] チャンネルが紐ついていないユーザーで、ユーザー生放送を事前に作成しておき、N Airから放送を開始できること (ウィンドウは出ない)
- [x] チャンネルが紐ついているユーザーで、ユーザー生放送をウィンドウから選択したとき、番組が作成されていない場合はダイアログが出ること
- [x] チャンネルが紐ついているユーザーで、ユーザー生放送をウィンドウから選択したとき、番組が作成されている場合は配信開始できる
- [x] チャンネルが紐ついているユーザーで、チャンネル番組を作成し、ウィンドウから、作成した番組で配信を開始できるこ
- [x] チャンネルが紐ついているユーザーで、チャンネル番組を作成せずウィンドウを開いたときに、番組を選ぶステップで文言が表示され、先に進めないこと
- [x] チャンネルが紐ついているユーザーで、ウィンドウが開かれた後、メインウィンドウでログアウトしてから種別を「チャンネル番組」としたときに操作不能にならないこと（本PRではエラー文言の対応までは実施していません）

# 関連するIssue（あれば）
https://github.com/n-air-app/n-air-app/issues/442