### PR TITLE
feat(i18n): nicoliveProgramSelector 英訳

### DIFF
--- a/app/i18n/en-US/streaming.json
+++ b/app/i18n/en-US/streaming.json
@@ -38,35 +38,35 @@
     "description": "Optimize simple settings to deliver Nicolive."
   },
   "nicoliveProgramSelector": {
-    "title": "Select a programs to start streaming on",
+    "title": "Select a program",
     "steps": {
       "providerTypeSelect": {
-        "menuTitle": "",
-        "title": "",
-        "description": ""
+        "menuTitle": "Program Type",
+        "title": "Select a program type",
+        "description": "Select a type of the program you will start streaming to."
       },
       "channelSelect": {
-        "menuTitle": "",
-        "title": "",
-        "description": ""
+        "menuTitle": "Channel",
+        "title": "Select a channel",
+        "description": "Select a channel you will start streaming on from the list."
       },
       "programSelect": {
-        "menuTitle": "",
-        "title":"",
-        "description": ""
+        "menuTitle": "Program",
+        "title":"Select a program",
+        "description": "Select a program you will start streaming to."
       },
       "confirm": {
-        "menuTitle": "",
-        "title": "",
-        "description": ""
+        "menuTitle": "Confirmation",
+        "title": "Confirmation",
+        "description": "You will start streaming to the following program."
       }
     },
     "providerTypeProgram": {
-      "channel": "",
-      "user": ""
+      "channel": "Channel program",
+      "user": "User program"
     },
-    "noChannelPrograms": "",
-    "done": "Select a program"
+    "noChannelPrograms": "There is no program on the selected channel.<br />Create a program on the channel or make sure you selected a correct channel.",
+    "done": "Start streaming"
   },
   "FPS": "FPS",
   "resolution": "resolution",


### PR DESCRIPTION
# このpull requestが解決する内容
番組選択ダイアログを英訳します

# 動作確認手順
1. N Air 起動
2. 設定 から言語を 「English」に設定する（再起動）
3. ニコニコに、チャンネル配信権限があるアカウントでログインして配信開始しようとする

<img width="600" alt="1" src="https://user-images.githubusercontent.com/905919/98069823-0bb75980-1ea3-11eb-8751-895fa2858700.png">
<img width="600" alt="2" src="https://user-images.githubusercontent.com/905919/98069824-0c4ff000-1ea3-11eb-849e-e5b18bc5ef0e.png">
※ lv の部分は加工しています
<img width="600" alt="3" src="https://user-images.githubusercontent.com/905919/98070351-55547400-1ea4-11eb-8ef4-0da43549eccf.png">
<img width="600" alt="3a" src="https://user-images.githubusercontent.com/905919/98069825-0ce88680-1ea3-11eb-8150-0345d93489d5.png">
<img width="600" alt="4" src="https://user-images.githubusercontent.com/905919/98070357-5ab1be80-1ea4-11eb-9fac-2d97194e8488.png">
<img width="600" alt="4u" src="https://user-images.githubusercontent.com/905919/98069828-0d811d00-1ea3-11eb-9dcb-2d3530887c5e.png">


# 関連するIssue（あれば）
https://github.com/n-air-app/n-air-app/issues/442