### PR TITLE
fix(nicolive-client): 意図しない最大ビットレートが与えられたときは192kbps扱いする

### DIFF
--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -483,6 +483,8 @@ export class NicoliveClient {
         return 384;
       case '192kbps288p':
         return 192;
+      default: // 来ないはず
+        return 192;
     }
   }
 


### PR DESCRIPTION
# このpull requestが解決する内容
そんなことはないとは思うのですが、意図しない最大ビットレートがサーバからもし与えられた場合は192kbps扱いしようと思います。

[HTTP 2XX系でないレスポンスを受け取った時の挙動が192kbps扱いなので、それに準拠する形です。](https://github.com/matsuyuki-a/n-air-app/pull/8/files#diff-506f005a8c1058fb2c3363183c8926ade2904ad4c9586733c5d1e87e0da51fa8R472)

# 動作確認手順

- [x] yarn test:unit

# 関連するIssue（あれば）
https://github.com/n-air-app/n-air-app/pull/470/files/2980f20f7d1bd1474d7b01396da1adc155f2cabf#diff-506f005a8c1058fb2c3363183c8926ade2904ad4c9586733c5d1e87e0da51fa8